### PR TITLE
Add start/stop/status charm actions

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -1,0 +1,8 @@
+status:
+  description: Retrieve MicroK8s status
+
+start:
+  description: Start MicroK8s services
+
+stop:
+  description: Stop MicroK8s services

--- a/src/microk8scluster.py
+++ b/src/microk8scluster.py
@@ -137,6 +137,10 @@ class MicroK8sCluster(Object):
         self.framework.observe(charm.on.config_changed, self._update_etc_hosts)
         self.framework.observe(charm.on.config_changed, self._refresh_channel)
 
+        self.framework.observe(charm.on.start_action, self._microk8s_start)
+        self.framework.observe(charm.on.stop_action, self._microk8s_stop)
+        self.framework.observe(charm.on.status_action, self._microk8s_status)
+
         self.framework.observe(charm.on[relation_name].relation_changed, self._on_relation_changed)
         self.framework.observe(charm.on[relation_name].relation_departed, self._on_relation_departed)
 
@@ -389,3 +393,12 @@ class MicroK8sCluster(Object):
             logger.error('Not all hosts not found in k8s, deferring event.  Missing: {}'.format(', '.join(missing)))
             event.defer()
         self.model.unit.status = ActiveStatus()
+
+    def _microk8s_start(self, event):
+        subprocess.check_call(['/snap/bin/microk8s', 'start'])
+
+    def _microk8s_stop(self, event):
+        subprocess.check_call(['/snap/bin/microk8s', 'stop'])
+
+    def _microk8s_status(self, event):
+        subprocess.check_call(['/snap/bin/microk8s', 'status'])


### PR DESCRIPTION
### Summary

Add support for some basic MicroK8s actions in the charm.

### Changes

- Support running `microk8s status`, `microk8s start` and `microk8s stop` as Juju actions.
- Add unit tests.