### PR TITLE
Fix node removal from Kubernetes cluster

### DIFF
--- a/src/hostnamemanager.py
+++ b/src/hostnamemanager.py
@@ -29,9 +29,14 @@ class HostnameManager(Object):
         self._state.forgotten[unit_name] = unit_name
 
     @property
+    def all_peers(self):
+        """Return a dict mapping peers' unit names to their hostnames."""
+        return dict(self._state.peer_hostnames)
+
+    @property
     def peers(self):
         """Return a dict mapping peers' unit names to their hostnames, except forgotten units."""
-        return {hk: hv for hk, hv in self._state.peer_hostnames.items() if hk not in self._state.forgotten}
+        return {k: v for k, v in self._state.peer_hostnames.items() if k not in self._state.forgotten}
 
     def _announce_hostname(self, event):
         """Announce our hostname."""

--- a/src/microk8scluster.py
+++ b/src/microk8scluster.py
@@ -345,7 +345,7 @@ class MicroK8sCluster(Object):
             logger.info("{} is still around. Waiting for it to go away.".format(event.departing_unit_name))
             event.defer()
             return
-        hostname = self.hostnames.peers.get(event.departing_unit_name)
+        hostname = self.hostnames.all_peers.get(event.departing_unit_name)
         if not hostname:
             logger.error("Cannot remove node: hostname for {} not found.".format(event.departing_unit_name))
             return

--- a/tests/test_hostnamemanager.py
+++ b/tests/test_hostnamemanager.py
@@ -1,0 +1,41 @@
+from collections import namedtuple
+from unittest import TestCase
+from unittest.mock import patch
+
+from ops.testing import Harness
+
+from charm import MicroK8sCharm
+
+MockEvent = namedtuple("MockEvent", ["unit", "relation"])
+MockUnit = namedtuple("MockUnit", ["name"])
+MockData = namedtuple("MockData", ["data"])
+
+
+class TestHostnameManager(TestCase):
+    def setUp(self):
+        self.harness = Harness(MicroK8sCharm)
+        self.harness.begin()
+
+        unit = MockUnit(name="microk8s/10")
+        event = MockEvent(unit=unit, relation=MockData(data={unit: {"hostname": "myhostname"}}))
+        self.event = event
+
+    def test_remember_empty(self):
+        self.harness.charm.cluster.hostnames._remember_hostname(MockEvent(unit=None, relation=None))
+        self.assertEqual(self.harness.charm.cluster.hostnames.peers, {})
+
+    def test_remember(self):
+        self.harness.charm.cluster.hostnames._remember_hostname(self.event)
+        self.assertEqual(self.harness.charm.cluster.hostnames.all_peers, {"microk8s/10": "myhostname"})
+        self.assertEqual(self.harness.charm.cluster.hostnames.peers, {"microk8s/10": "myhostname"})
+
+    def test_forget(self):
+        self.harness.charm.cluster.hostnames._remember_hostname(self.event)
+        self.assertEqual(self.harness.charm.cluster.hostnames.peers, {"microk8s/10": "myhostname"})
+
+        with patch("os.environ.get") as _get:
+            _get.return_value = "microk8s/10"
+            self.harness.charm.cluster.hostnames._forget_hostname(None)
+
+        self.assertEqual(self.harness.charm.cluster.hostnames.all_peers, {"microk8s/10": "myhostname"})
+        self.assertEqual(self.harness.charm.cluster.hostnames.peers, {})


### PR DESCRIPTION
### Summary

Closes #13 

### Changes

- Retrieve hostname of departing from list of all peers (including ones that should be forgotten)
- Add unit tests for hostnamemanager