### PR TITLE
Prevent downgrading MicroK8s cluster via channel refreshes

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -112,3 +112,19 @@ def retry_until_zero_rc(cmd, max_tries, timeout_seconds):
                 e.stderr,
             )
             sleep(timeout_seconds)
+
+
+def get_kubernetes_version_from_channel(channel: str) -> list:
+    """Retrieve the Kubernetes version implied by a snap channel."""
+    track = channel.split("/")[0]
+    return list(map(int, track.split(".")))
+
+
+def check_kubernetes_version_is_older(current: str, new: str):
+    """Check if the Kubernetes version implied by channel new is older than the current."""
+    try:
+        current_version = get_kubernetes_version_from_channel(current)
+        new_version = get_kubernetes_version_from_channel(new)
+        return current_version > new_version
+    except (TypeError, ValueError):
+        return False

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,7 +2,7 @@
 # See LICENSE file for licensing details.
 
 import unittest
-from utils import join_url_from_add_node_output
+from utils import check_kubernetes_version_is_older, join_url_from_add_node_output, get_kubernetes_version_from_channel
 
 
 class TestUtils(unittest.TestCase):
@@ -26,3 +26,29 @@ class TestUtils(unittest.TestCase):
         )
         expected = "that"
         self.assertEqual(join_url_from_add_node_output(output), expected)
+
+    def test_get_kubernetes_version_from_channel(self):
+        for channel, result in [
+            ("1.20", [1, 20]),
+            ("1.21/stable", [1, 21]),
+            ("1.22/latest/edge", [1, 22]),
+        ]:
+            self.assertEqual(get_kubernetes_version_from_channel(channel), result)
+
+        for channel in ["", "latest", "latest/stable", "latest/edge/branch"]:
+            with self.assertRaises((TypeError, ValueError)):
+                get_kubernetes_version_from_channel(channel)
+
+    def test_check_kubernetes_version_is_older(self):
+        for current, new, result in [
+            ("1.20", "1.21", False),
+            ("1.20", "1.20", False),
+            ("1.20", "1.20/stable/branch", False),
+            ("latest", "1.20/stable/branch", False),
+            ("1.21", "1.20/stable/branch", True),
+            ("1.20", "latest", False),
+            ("1.9", "1.10", False),
+            ("latest/stable", "latest/edge/worker", False),
+            ("latest/edge/worker", "latest/stable", False),
+        ]:
+            self.assertEqual(check_kubernetes_version_is_older(current, new), result)


### PR DESCRIPTION
### Summary

Add logic that prevents downgrading the MicroK8s cluster. This has been known to lead to issues with the cluster, so we add (best-effort) guards in the charm to prevent people from breaking their clusters.

### Changes

- When updating the `channel` charm configuration option, figure out the implied Kubernetes version (by parsing the track)
- Compare the new track with the one currently installed. If both refer to specific Kubernetes versions, then make sure that the new version is equal or newer than the installed one.
- If parsing the Kubernetes version fails (e.g. for `latest`, `auto`, etc), then allow the upgrade.