### PR TITLE
Add configuration for csr.conf.template

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -56,3 +56,51 @@ options:
       When set, add node IPs to /etc/hosts. Use this if the substrate does not provide DNS.
     type: boolean
     default: false
+
+  csr_conf_template:
+    description: >
+      Configuration for the csr.conf.template. Can be used to add IP and DNS SANs.
+      %UNIT_PRIVATE_ADDRESS% and %UNIT_PUBLIC_ADDRESS% will be replaced by Juju to
+      match the private and public address for each unit.
+
+      If empty, then Juju will not manage the file.
+    type: string
+    default: |
+      # This file is managed by Juju. Manual changes may be lost at any time.
+
+      [ req ]
+      default_bits = 2048
+      prompt = no
+      default_md = sha256
+      req_extensions = req_ext
+      distinguished_name = dn
+
+      [ dn ]
+      C = GB
+      ST = Canonical
+      L = Canonical
+      O = Canonical
+      OU = Canonical
+      CN = 127.0.0.1
+
+      [ req_ext ]
+      subjectAltName = @alt_names
+
+      [ alt_names ]
+      DNS.1 = kubernetes
+      DNS.2 = kubernetes.default
+      DNS.3 = kubernetes.default.svc
+      DNS.4 = kubernetes.default.svc.cluster
+      DNS.5 = kubernetes.default.svc.cluster.local
+      IP.1 = 127.0.0.1
+      IP.2 = 10.152.183.1
+      #MOREIPS
+      IP.unit-private-address = %UNIT_PRIVATE_ADDRESS%
+      IP.unit-public-address = %UNIT_PUBLIC_ADDRESS%
+
+      [ v3_ext ]
+      authorityKeyIdentifier=keyid,issuer:always
+      basicConstraints=CA:FALSE
+      keyUsage=keyEncipherment,dataEncipherment,digitalSignature
+      extendedKeyUsage=serverAuth,clientAuth
+      subjectAltName=@alt_names

--- a/src/microk8scluster.py
+++ b/src/microk8scluster.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 import json
 import yaml
 import logging
@@ -28,6 +29,7 @@ logger = logging.getLogger(__name__)
 
 
 CONTAINERD_ENV_SNAP_PATH = "/var/snap/microk8s/current/args/containerd-env"
+CSR_CONF_TEMPLATE_SNAP_PATH = "/var/snap/microk8s/current/certs/csr.conf.template"
 
 
 class EventError(Exception):
@@ -137,6 +139,7 @@ class MicroK8sCluster(Object):
         self.framework.observe(charm.on.config_changed, self._manage_addons)
         self.framework.observe(charm.on.config_changed, self._update_etc_hosts)
         self.framework.observe(charm.on.config_changed, self._refresh_channel)
+        self.framework.observe(charm.on.config_changed, self._update_csr_conf)
 
         self.framework.observe(charm.on.start_action, self._microk8s_start)
         self.framework.observe(charm.on.stop_action, self._microk8s_stop)
@@ -394,6 +397,34 @@ class MicroK8sCluster(Object):
             logger.error("Not all hosts not found in k8s, deferring event. Missing: {}".format(", ".join(missing)))
             event.defer()
         self.model.unit.status = ActiveStatus()
+
+    def _update_csr_conf(self, event):
+        try:
+            with open(CSR_CONF_TEMPLATE_SNAP_PATH, "r") as fin:
+                existing = fin.read()
+        except Exception:
+            # We could be racing install, or who knows what else, so just try again later.
+            event.defer()
+            return
+
+        private_address = subprocess.check_output(["unit-get", "private-address"]).decode().strip()
+        public_address = subprocess.check_output(["unit-get", "public-address"]).decode().strip()
+
+        csr_conf = self.model.config["csr_conf_template"]
+        if not csr_conf:
+            return
+
+        csr_conf = csr_conf.replace("%UNIT_PRIVATE_ADDRESS%", private_address)
+        csr_conf = csr_conf.replace("%UNIT_PUBLIC_ADDRESS%", public_address)
+        if csr_conf == existing:
+            return
+
+        logger.info("Updating csr.conf.template")
+        with open(CSR_CONF_TEMPLATE_SNAP_PATH, "w") as fout:
+            fout.write(csr_conf)
+
+        # re-run the configure script to update certificates
+        subprocess.check_call(["/usr/bin/snap", "set", "microk8s", "charm-update-certs={}".format(datetime.now())])
 
     def _microk8s_start(self, event):
         subprocess.check_call(["/snap/bin/microk8s", "start"])

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -4,7 +4,8 @@
 import subprocess
 
 import unittest
-from unittest.mock import call, patch
+from unittest.mock import call, mock_open, patch, ANY
+
 
 from ops.model import ActiveStatus
 from ops.testing import Harness
@@ -19,53 +20,81 @@ class TestCharm(unittest.TestCase):
     @patch("kubectl.patch")
     @patch("kubectl.get")
     @patch("subprocess.check_call")
-    def test_begin_with_initial_hooks_on_leader(self, _check_call, _get, _patch):
+    @patch("subprocess.check_output")
+    @patch("builtins.open", new_callable=mock_open, read_data="")
+    def test_begin_with_initial_hooks_on_leader(self, _open, _check_output, _check_call, _get, _patch):
         """The leader installs microk8s, enables addons, and opens ports."""
         _get.return_value.returncode = 0
         _get.return_value.stdout = b"{}"
         _patch.return_value.returncode = 0
 
+        _check_output.side_effect = [b"1.1.1.1", b"2.2.2.2"]
+        self.harness.update_config({"containerd_env": ""})
+
         self.harness.set_leader(True)
         self.harness.begin_with_initial_hooks()
-        expected_subprocess_calls = [
-            call(["/usr/bin/apt-get", "install", "--yes", "nfs-common"]),
-            call(["/usr/bin/snap", "install", "--classic", "microk8s"]),
-            call(["/usr/sbin/addgroup", "ubuntu", "microk8s"]),
-            call(["/usr/bin/snap", "alias", "microk8s.kubectl", "kubectl"]),
-            call(["open-port", "16443/tcp"]),
-            call(["open-port", "80/tcp"]),
-            call(["open-port", "443/tcp"]),
-            call(["/snap/bin/microk8s", "enable", "dns", "ingress"], stdout=subprocess.PIPE, stderr=subprocess.PIPE),
-        ]
-        self.assertEqual(len(expected_subprocess_calls), len(_check_call.call_args_list))
-        for actual, expected in zip(_check_call.call_args_list, expected_subprocess_calls):
-            self.assertEqual(actual, expected)
         self.assertEqual(self.harness.charm.unit.status, ActiveStatus())
+        self.assertEqual(
+            _check_call.call_args_list,
+            [
+                call(["/usr/bin/apt-get", "install", "--yes", "nfs-common"]),
+                call(["/usr/bin/snap", "install", "--classic", "microk8s"]),
+                call(["/usr/sbin/addgroup", "ubuntu", "microk8s"]),
+                call(["/usr/bin/snap", "alias", "microk8s.kubectl", "kubectl"]),
+                call(["open-port", "16443/tcp"]),
+                call(["open-port", "80/tcp"]),
+                call(["open-port", "443/tcp"]),
+                call(
+                    ["/snap/bin/microk8s", "enable", "dns", "ingress"], stdout=subprocess.PIPE, stderr=subprocess.PIPE
+                ),
+                call(["/usr/bin/snap", "set", "microk8s", ANY]),
+            ],
+        )
+        self.assertEqual(
+            _check_output.call_args_list,
+            [
+                call(["unit-get", "private-address"]),
+                call(["unit-get", "public-address"]),
+            ],
+        )
 
     @patch("kubectl.patch")
     @patch("kubectl.get")
     @patch("subprocess.check_call")
-    def test_begin_with_initial_hooks_on_follower(self, _check_call, _get, _patch):
+    @patch("subprocess.check_output")
+    @patch("builtins.open", new_callable=mock_open, read_data="")
+    def test_begin_with_initial_hooks_on_follower(self, _open, _check_output, _check_call, _get, _patch):
         """A follower installs microk8s and opens ports.  (A follower does not enable addons.)"""
         _get.return_value.returncode = 0
         _get.return_value.stdout = b"{}"
         _patch.return_value.returncode = 0
 
+        _check_output.side_effect = [b"1.1.1.1", b"2.2.2.2"]
+        self.harness.update_config({"containerd_env": ""})
+
         self.harness.set_leader(False)
         self.harness.begin_with_initial_hooks()
-        expected_subprocess_calls = [
-            ["/usr/bin/apt-get", "install", "--yes", "nfs-common"],
-            ["/usr/bin/snap", "install", "--classic", "microk8s"],
-            ["/usr/sbin/addgroup", "ubuntu", "microk8s"],
-            ["/usr/bin/snap", "alias", "microk8s.kubectl", "kubectl"],
-            ["open-port", "16443/tcp"],
-            ["open-port", "80/tcp"],
-            ["open-port", "443/tcp"],
-        ]
-        self.assertEqual(len(expected_subprocess_calls), len(_check_call.call_args_list))
-        for actual, expected in zip(_check_call.call_args_list, [call(c) for c in expected_subprocess_calls]):
-            self.assertEqual(actual, expected)
         self.assertEqual(self.harness.charm.unit.status, ActiveStatus())
+        self.assertEqual(
+            _check_call.call_args_list,
+            [
+                call(["/usr/bin/apt-get", "install", "--yes", "nfs-common"]),
+                call(["/usr/bin/snap", "install", "--classic", "microk8s"]),
+                call(["/usr/sbin/addgroup", "ubuntu", "microk8s"]),
+                call(["/usr/bin/snap", "alias", "microk8s.kubectl", "kubectl"]),
+                call(["open-port", "16443/tcp"]),
+                call(["open-port", "80/tcp"]),
+                call(["open-port", "443/tcp"]),
+                call(["/usr/bin/snap", "set", "microk8s", ANY]),
+            ],
+        )
+        self.assertEqual(
+            _check_output.call_args_list,
+            [
+                call(["unit-get", "private-address"]),
+                call(["unit-get", "public-address"]),
+            ],
+        )
 
     @patch("subprocess.check_call")
     def test_action_start(self, _check_call):


### PR DESCRIPTION
### Summary

Add option to configure csr.conf.template. The main purpose of this change is to be able to include the private and the public unit address from Juju. The private address might not be necessary (typically, it will be an IP address known to the machine, so MicroK8s will add it automatically. However, this is important for the public address, because for AWS/OpenStack and other clouds it will typically be a floating IP address, which the MicroK8s snap has no way of knowing.

### Changes

- Add new `csr_conf_template` option. This is to prevent the charm from doing too much magic that the user cannot control behind the scenes, as well follow suit with the rest of the charm config options. The default value is copied over from the MicroK8s snap, with the addition of the following section:

  ```
  IP.unit-private-address = %UNIT_PRIVATE_ADDRESS%
  IP.unit-public-address = %UNIT_PUBLIC_ADDRESS%
  ```

- On `config_changed` events, update the `csr.conf.template` file (if changed). Also, run a (dummy) `snap set microk8s $key=$value` command, so that the snap `configure` hook fires up and updates any certificates as needed. `%UNIT_PRIVATE_ADDRESS%` and `%UNIT_PUBLIC_ADDRESS%` are replaced by the charm with the private and public address of the unit respectively, as returned by Juju.

- Update unit tests accordingly, and also attempt to make them a bit more tidy.

### Testing

The charm for this PR can be tested with (revision 5):

```
juju deploy microk8s --channel edge/sans
```
