### PR TITLE
Add charm `kubeconfig` action

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# microk8s
+# MicroK8s
 
 ## The smallest, fastest Kubernetes
 
@@ -14,12 +14,21 @@ Single-package fully conformant lightweight Kubernetes that works on [42 flavour
 This charm deploys and manages a MicroK8s cluster. It can handle scaling up and down.
 
 **Minimum Requirements**: 1 vCPU and 1GB RAM.
+
 **Recommended Requirements**: 2 vCPUs and 4GB RAM, 20GB disk.
 
 Make sure to account for extra requirements depending on the workload you are planning to deploy.
 
 ```bash
 juju deploy --constraints 'cores=2 mem=4G' microk8s
+```
+
+Then, retrieve the kubeconfig file with:
+
+```bash
+mkdir -p ~/.kube
+juju run-action --unit microk8s/leader kubeconfig
+juju scp microk8s/leader:config ~/.kube/config
 ```
 
 ### Addons

--- a/actions.yaml
+++ b/actions.yaml
@@ -6,3 +6,6 @@ start:
 
 stop:
   description: Stop MicroK8s services
+
+kubeconfig:
+  description: Build kubeconfig file to access the MicroK8s cluster


### PR DESCRIPTION
### Summary

Add new charm action `kubeconfig`, meant to build a kubeconfig file for accessing the cluster via its public address.

Also, update README with instructions for retrieving the kubeconfig file for the cluster.

### Notes

- The config file is created at `~/config`, and can be retrieved via `juju scp`.
- The public address of the unit is used as server address.

### Testing

```
juju deploy microk8s --channel edge --constraints 'allocate-public-ip=true'
juju run-action microk8s/leader --wait
mkdir ~/.kube
juju scp microk8s/leader:config ~/.kube/config
kubectl get pod -A
```