### PR TITLE
Only run CLA check on pull requests

### DIFF
--- a/.github/workflows/cla-check.yml
+++ b/.github/workflows/cla-check.yml
@@ -1,8 +1,6 @@
 name: cla-check
 
 on:
-  push:
-    branches: [master, default]
   pull_request:
     branches: [master, default]
 


### PR DESCRIPTION
### Summary

Running the CLA check action should only run on pull requests.

In fact, it fails on push events: https://github.com/canonical/charm-microk8s/runs/4760673001?check_suite_focus=true