### PR TITLE
Document juju expose microk8s command

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ juju run-action --unit microk8s/leader kubeconfig
 juju scp microk8s/leader:config ~/.kube/config
 ```
 
+In some clouds (e.g. OpenStack), you will need to expose the application before you can access it from the external network:
+
+```bash
+juju expose microk8s
+```
+
 ### Addons
 
 Enable addons with:


### PR DESCRIPTION
### Summary

In some clouds (e.g. OpenStack), where security groups are used to limit ingress traffic, Juju will only open ports if the application is exposed.

Document this in the project README, so that it shows up in the CharmHub page as well.

References https://github.com/canonical/microk8s/issues/3095#issue-1216031091