### PR TITLE
Add tests for Ubuntu Jammy and small improvements

### DIFF
--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -42,6 +42,7 @@ jobs:
           juju add-model testing
           export MK8S_CLUSTER_SIZE=1
           export MK8S_CHARM=./microk8s.charm
+          export MK8S_SERIES=focal
           sg lxd -c 'tox -e integration -- --model testing'
       - name: Retrieve artifacts
         if: always()

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -41,7 +41,6 @@ jobs:
           juju add-model testing
           export MK8S_CLUSTER_SIZE=1
           export MK8S_CHARM=./microk8s.charm
-          export MK8S_KEEP_MODEL=1
           sg lxd -c 'tox -e integration -- --model testing'
       - name: Retrieve artifacts
         if: always()

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -21,12 +21,13 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: lxd
+          lxd-channel: 4.0/stable
       - name: Add user to lxd group
         run: sudo usermod -a -G lxd $USER
       - name: Build charm
         run: |
           cp hacks/lxd-profile.yaml .
-          sg lxd -c 'charmcraft build -v'
+          charmcraft pack -v --destructive-mode
           mv microk8s*.charm microk8s.charm
       - name: Upload charm
         uses: actions/upload-artifact@v3.0.0
@@ -35,7 +36,7 @@ jobs:
           path: ./microk8s.charm
       - name: Install tox
         run: |
-          sudo apt-get install tox
+          pip3 install tox
       - name: Run integration tests
         run: |
           juju add-model testing

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -6,3 +6,5 @@ bases:
     run-on:
     - name: "ubuntu"
       channel: "20.04"
+    - name: "ubuntu"
+      channel: "22.04"

--- a/integration_tests.sh
+++ b/integration_tests.sh
@@ -4,12 +4,14 @@
 export MK8S_KEEP_MODEL=1
 # specify charmhub name or local path. Set to `build` to build charm from source
 export MK8S_CHARM=microk8s
-# test for multiple snap versions, e.g. '1.20 1.21 1.22'
+# test for multiple snap versions, e.g. '1.21 1.22 1.23' (space separated list)
 export MK8S_SNAP_CHANNELS=''
 # size of cluster to create during the tests
 export MK8S_CLUSTER_SIZE=3
 # machine constraints for the MicroK8s cluster (passed directly to Juju)
 export MK8S_CONSTRAINTS='mem=4G root-disk=20G'
+# machine series to check against (space separated list)
+export MK8S_SERIES='focal jammy'
 # optionally, configure an HTTP proxy for the integration tests
 # export MK8S_PROXY='http://squid.internal:3128'
 # export MK8S_NO_PROXY='10.0.0.0/8,127.0.0.0/16,192.168.0.0/16'

--- a/integration_tests.sh
+++ b/integration_tests.sh
@@ -1,7 +1,5 @@
 #!/bin/bash -ex
 
-# preserve the created juju model after tests finish for additional introspection
-export MK8S_KEEP_MODEL=1
 # specify charmhub name or local path. Set to `build` to build charm from source
 export MK8S_CHARM=microk8s
 # test for multiple snap versions, e.g. '1.21 1.22 1.23' (space separated list)

--- a/ops_tests/test_integration.py
+++ b/ops_tests/test_integration.py
@@ -10,16 +10,14 @@ LOG = logging.getLogger(__name__)
 
 @pytest.mark.abort_on_fail
 @pytest.mark.parametrize("snap_channel", os.getenv("MK8S_SNAP_CHANNELS", "").split() or [""])
-async def test_deploy_cluster(ops_test: OpsTest, snap_channel):
+@pytest.mark.parametrize("series", os.getenv("MK8S_SERIES", "").split() or ["focal", "jammy"])
+async def test_deploy_cluster(ops_test: OpsTest, snap_channel: str, series: str):
     units = int(os.getenv("MK8S_CLUSTER_SIZE", 3))
     charm = os.getenv("MK8S_CHARM", "microk8s")
     constraints = os.getenv("MK8S_CONSTRAINTS", "mem=4G root-disk=20G cores=2")
     charm_channel = os.getenv("MK8S_CHARM_CHANNEL")
     proxy = os.getenv("MK8S_PROXY")
     no_proxy = os.getenv("MK8S_NO_PROXY")
-
-    if os.getenv("MK8S_KEEP_MODEL"):
-        ops_test.keep_model = True
 
     if charm == "build":
         LOG.info("Build charm")
@@ -54,7 +52,7 @@ async def test_deploy_cluster(ops_test: OpsTest, snap_channel):
             ]
         )
 
-    LOG.info("Deploy microk8s charm %s with configuration %s", charm, charm_config)
+    LOG.info("Deploy microk8s charm %s on %s with configuration %s", charm, series, charm_config)
     app = await ops_test.model.deploy(
         charm,
         application_name=application_name,
@@ -62,12 +60,11 @@ async def test_deploy_cluster(ops_test: OpsTest, snap_channel):
         config=charm_config,
         channel=charm_channel,
         constraints=constraints,
+        series=series,
         force=True,
     )
 
     LOG.info("Wait for cluster")
     await ops_test.model.wait_for_idle(apps=[app.name], timeout=60 * 60)
 
-    # Remove application after test
-    if not ops_test.keep_model:
-        await ops_test.model.applications[app.name].remove()
+    await ops_test.model.applications[app.name].remove()

--- a/ops_tests/test_integration.py
+++ b/ops_tests/test_integration.py
@@ -37,9 +37,9 @@ async def test_deploy_cluster(ops_test: OpsTest, snap_channel: str, series: str)
         await ops_test.model.set_config({"no-proxy": no_proxy})
 
     charm_config = {}
-    application_name = None
+    application_name = "microk8s-{}".format(series)
     if snap_channel:
-        application_name = re.sub("[^a-z0-9]", "", "microk8s{}".format(snap_channel))
+        application_name += "-v" + re.sub("[^a-z0-9]", "", snap_channel)
         charm_config["channel"] = snap_channel
     if proxy:
         charm_config["containerd_env"] = "\n".join(

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@
 coverage
 flake8
 pytest
-pytest-operator < 0.9
+pytest-operator
 pytest-xdist
 juju
 black


### PR DESCRIPTION
## Summary

Test the microk8s charm on both Ubuntu Jammy 22.04 and Ubuntu Focal 20.04, since we now support two series.

Also, update the version of pytest-operator and fix CI failures.

