### PR TITLE
Add yaml to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 ops
+pyyaml


### PR DESCRIPTION
The yaml library isn't installed within the snap filesystem. Trying to join the cluster
results in a traceback. See issue #39.

Looks like we need more than just adding it to the requirements.txt file. The integration tests on OpenStack still failed at the same place. So I assume something else is required to install pyyaml in the snap image.

Fixes #39