### PR TITLE
Add proper support for LXD

### DIFF
--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -26,7 +26,6 @@ jobs:
         run: sudo usermod -a -G lxd $USER
       - name: Build charm
         run: |
-          cp hacks/lxd-profile.yaml .
           charmcraft pack -v --destructive-mode
           mv microk8s*.charm microk8s.charm
       - name: Upload charm

--- a/README.md
+++ b/README.md
@@ -20,7 +20,13 @@ This charm deploys and manages a MicroK8s cluster. It can handle scaling up and 
 Make sure to account for extra requirements depending on the workload you are planning to deploy.
 
 ```bash
-juju deploy --constraints 'cores=2 mem=4G' microk8s
+juju deploy microk8s --constraints 'cores=2 mem=4G'
+```
+
+Alternatively, to specify the MicroK8s version to install, you can use:
+
+```bash
+juju deploy microk8s --constraints 'cores=2 mem=4G' --config channel=1.25
 ```
 
 Then, retrieve the kubeconfig file with:
@@ -70,12 +76,5 @@ The integration tests require a bootstrapped Juju controller.
 ## Build from source
 
 ```bash
-charmcraft pack
-```
-
-### LXD
-
-```bash
-cp hacks/lxd-profile.yaml .
 charmcraft pack
 ```

--- a/lxd-profile.yaml
+++ b/lxd-profile.yaml
@@ -1,6 +1,6 @@
 name: microk8s
 config:
-  boot.autostart: "true"
+  # boot.autostart: "true"
   linux.kernel_modules: ip_vs,ip_vs_rr,ip_vs_wrr,ip_vs_sh,ip_tables,ip6_tables,netlink_diag,nf_nat,overlay,br_netfilter
   raw.lxc: |
     lxc.apparmor.profile=unconfined
@@ -11,19 +11,19 @@ config:
   security.privileged: "true"
 description: ""
 devices:
-  aadisable:
-    path: /sys/module/nf_conntrack/parameters/hashsize
-    source: /sys/module/nf_conntrack/parameters/hashsize
-    type: disk
-  aadisable1:
-    path: /sys/module/apparmor/parameters/enabled
-    source: /dev/null
-    type: disk
+  # aadisable:
+  #   path: /sys/module/nf_conntrack/parameters/hashsize
+  #   source: /sys/module/nf_conntrack/parameters/hashsize
+  #   type: disk
   aadisable2:
     path: /dev/kmsg
     source: /dev/kmsg
-    type: disk
-  aadisable3:
-    path: /sys/fs/bpf
-    source: /sys/fs/bpf
-    type: disk
+    type: unix-char
+  # aadisable3:
+  #   path: /sys/fs/bpf
+  #   source: /sys/fs/bpf
+  #   type: disk
+  # aadisable4:
+  #   path: /proc/sys/net/netfilter/nf_conntrack_max
+  #   source: /proc/sys/net/netfilter/nf_conntrack_max
+  #   type: disk


### PR DESCRIPTION
## Summary

Support deploying the MicroK8s charm to LXD containers.

Closes #41 #40 

## Changes

- Always include LXD profile when building the charm
- Update deployment instructions to mention that the charm must now be deployed with `juju deploy microk8s --force`

## Caveats

It is now required that the charm is deployed with `--force`, due to required `disk` devices found in the LXD profile.

## Testing

```
juju deploy ./microk8s.charm --force --to lxd
```