### PR TITLE
Specify a TTL for join tokens

### DIFF
--- a/src/microk8scluster.py
+++ b/src/microk8scluster.py
@@ -335,7 +335,7 @@ class MicroK8sCluster(Object):
 
     def _on_add_unit(self, event):
         self.model.unit.status = MaintenanceStatus("adding {} to the microk8s cluster".format(event.unit.name))
-        output = subprocess.check_output(["/snap/bin/microk8s", "add-node", "--token-ttl", "-1"]).decode("utf-8")
+        output = subprocess.check_output(["/snap/bin/microk8s", "add-node", "--token-ttl", "36000"]).decode("utf-8")
         url = join_url_from_add_node_output(output)
         logger.debug("Generated join URL: {}".format(url))
         event.join_url = url


### PR DESCRIPTION
### Summary

Specify a TTL for tokens generated by the MicroK8s charm when joining new units into the cluster.

This allows watching the logs for issues that occur when joining the cluster.

The current behaviour of the charm, in case the `microk8s join` command fails, is to retry using the same token, which results in the first run containing the actual error, and subsequent ones only printing "Invalid token (500)".
