### PR TITLE
Add support for strict microk8s channels

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,5 +4,5 @@ flake8
 pytest
 pytest-operator
 pytest-xdist
-juju
+juju<3.0
 black


### PR DESCRIPTION
microk8s supports a strict mode snap for 1.25 and 1.26; add support to the charm to tweak behaviour to support use of these channels:

  - Use snap_microk8s rather than microk8s group
  - Drop use of --classic flag for strict channels