### PR TITLE
Remove defaults for coredns_config

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -27,29 +27,6 @@ options:
   coredns_config:
     description: The CoreDNS configuration.  If you're running on a restricted network, you may wish to change the forwaders.
     type: string
-    default: |
-      # This file is managed by Juju. Manual changes may be lost at any time.
-
-      .:53 {
-          errors
-          health {
-            lameduck 5s
-          }
-          ready
-          log . {
-            class error
-          }
-          kubernetes cluster.local in-addr.arpa ip6.arpa {
-            pods insecure
-            fallthrough in-addr.arpa ip6.arpa
-          }
-          prometheus :9153
-          forward . 8.8.8.8 8.8.4.4
-          cache 30
-          loop
-          reload
-          loadbalance
-      }
 
   manage_etc_hosts:
     description: >

--- a/src/microk8scluster.py
+++ b/src/microk8scluster.py
@@ -271,6 +271,9 @@ class MicroK8sCluster(Object):
         self.model.unit.status = ActiveStatus()
 
     def _coredns_config(self, event):
+        if not self.model.config.get("coredns_config"):
+            return
+
         result = kubectl.get("configmap", "coredns", namespace="kube-system")
         if result.returncode > 0:
             logger.error("Failed to get coredns configmap!  kubectl said: {}".format(result.stderr))


### PR DESCRIPTION
Currently dns server information need to be specified as part of addon config and corresponding coredns_config. However microk8s can handle updates in coredns_config if addon specified the dns server information.

This patch removes the defaults of coredns_config
where the forward is hardcoded to 8.8.8.8,8.8.4.4 so that microk8s can populate the correct configmap for coredns.

Fixes: #66