### PR TITLE
Fix join process

### DIFF
--- a/src/microk8scluster.py
+++ b/src/microk8scluster.py
@@ -387,7 +387,7 @@ class MicroK8sCluster(Object):
         url = event.join_url
         logger.debug("Using join URL: {}".format(url))
         try:
-            join_cmd = ["/snap/bin/microk8s", "join", url]
+            join_cmd = ["microk8s", "join", url]
             if self.model.config.get("skip_verify"):
                 join_cmd += ["--skip-verify"]
 


### PR DESCRIPTION
After attempting to debug why new units where not fully joining the microk8s cluster, the only difference I could identify was that the command was not fully pathi'ed when I had success.

This is inline with the new microk8s charm redux work.