### PR TITLE
Add content to kubeconfig action result

### DIFF
--- a/src/microk8scluster.py
+++ b/src/microk8scluster.py
@@ -517,10 +517,11 @@ class MicroK8sCluster(Object):
             pass
         kubeconfig["clusters"][0]["cluster"]["server"] = "https://{}:16443".format(public_address)
 
-        config_path = "/home/ubuntu/config"
-        with open(config_path, "w") as fout:
-            yaml.dump(kubeconfig, fout)
+        home = os.environ.get("HOME") or "/home/ubuntu"
+        config_path = Path(home) / "config"
+        with config_path.open("w") as fout:
+            yaml.safe_dump(kubeconfig, fout)
 
-        subprocess.check_call(["chown", "-R", "ubuntu:ubuntu", config_path])
         logger.info("Wrote kubeconfig to %s", config_path)
-        event.set_results({"kubeconfig": config_path})
+
+        event.set_results({"kubeconfig": config_path, "content": yaml.safe_dump(kubeconfig)})


### PR DESCRIPTION
Add the content of kubeconfig to kubeconfig action result with key content. To keep compatability
with the previous versions, writing config file
onto the filesystem is not removed.
Change the config file path to $HOME/config with
$HOME defaults to /home/ubuntu.

Fixes: #65