### PR TITLE
Ensure certificate re-issue enabled during cluster join

### DIFF
--- a/src/microk8scluster.py
+++ b/src/microk8scluster.py
@@ -386,6 +386,10 @@ class MicroK8sCluster(Object):
         self.model.unit.status = MaintenanceStatus("joining the microk8s cluster")
         url = event.join_url
         logger.debug("Using join URL: {}".format(url))
+
+        lockfile = Path(NO_CERT_REISSUE_LOCKFILE)
+        if lockfile.exists():
+            lockfile.unlink(missing_ok=True)
         try:
             join_cmd = ["microk8s", "join", url]
             if self.model.config.get("skip_verify"):
@@ -491,6 +495,12 @@ class MicroK8sCluster(Object):
 
     def _manage_cert_reissue_lock(self, event):
         """Manage lock file to enable/disable cert reissue."""
+        if self._state.joined:
+            logger.debug(
+                "Node is part of a cluster, ignoring certificate "
+                "re-issue lock configuration."
+            )
+            return
         disable_cert_reissue = self.model.config["disable_cert_reissue"]
         if disable_cert_reissue:
             Path(NO_CERT_REISSUE_LOCKFILE).touch()

--- a/src/microk8scluster.py
+++ b/src/microk8scluster.py
@@ -196,6 +196,10 @@ class MicroK8sCluster(Object):
         if channel != "auto":
             cmd.append("--channel={}".format(channel))
         subprocess.check_call(cmd)
+        try:
+            subprocess.check_call(["microk8s", "status", "--wait-ready", "--timeout=300"])
+        except subprocess.CalledProcessError:
+            logger.exception("timed out waiting for node to come up")
         group = "microk8s"
         if "strict" in channel:
             group = "snap_microk8s"
@@ -496,10 +500,7 @@ class MicroK8sCluster(Object):
     def _manage_cert_reissue_lock(self, event):
         """Manage lock file to enable/disable cert reissue."""
         if self._state.joined:
-            logger.debug(
-                "Node is part of a cluster, ignoring certificate "
-                "re-issue lock configuration."
-            )
+            logger.debug("Node is part of a cluster, ignoring certificate " "re-issue lock configuration.")
             return
         disable_cert_reissue = self.model.config["disable_cert_reissue"]
         if disable_cert_reissue:

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -41,6 +41,7 @@ class TestCharm(unittest.TestCase):
                 call(["/usr/bin/apt-get", "install", "--yes", "nfs-common"]),
                 call(["/usr/bin/apt-get", "install", "--yes", "linux-modules-extra-5.13"]),
                 call(["/usr/bin/snap", "install", "microk8s", "--classic"]),
+                call(["microk8s", "status", "--wait-ready", "--timeout=300"]),
                 call(["/usr/sbin/addgroup", "ubuntu", "microk8s"]),
                 call(["/usr/bin/snap", "alias", "microk8s.kubectl", "kubectl"]),
                 call(["open-port", "16443/tcp"]),
@@ -94,6 +95,7 @@ class TestCharm(unittest.TestCase):
                 call(["/usr/bin/apt-get", "install", "--yes", "nfs-common"]),
                 call(["/usr/bin/apt-get", "install", "--yes", "linux-modules-extra-5.13"]),
                 call(["/usr/bin/snap", "install", "microk8s", "--channel=1.26-strict"]),
+                call(["microk8s", "status", "--wait-ready", "--timeout=300"]),
                 call(["/usr/sbin/addgroup", "ubuntu", "snap_microk8s"]),
                 call(["/usr/bin/snap", "alias", "microk8s.kubectl", "kubectl"]),
                 call(["open-port", "16443/tcp"]),
@@ -142,6 +144,7 @@ class TestCharm(unittest.TestCase):
             [
                 call(["/usr/bin/apt-get", "install", "--yes", "nfs-common"]),
                 call(["/usr/bin/snap", "install", "microk8s", "--classic"]),
+                call(["microk8s", "status", "--wait-ready", "--timeout=300"]),
                 call(["/usr/sbin/addgroup", "ubuntu", "microk8s"]),
                 call(["/usr/bin/snap", "alias", "microk8s.kubectl", "kubectl"]),
                 call(["open-port", "16443/tcp"]),


### PR DESCRIPTION
The cluster join process relies on certificates being re-issued; re-enable this if the charm has previous disabled this feature and allow the `microk8s join` command to set its desired state for this flag on completion.

Any changes to the charm configuration option will then be ignored.