### PR TITLE
Add rbac integration tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     strategy:
-      fail-fast: true
+      # fail-fast: true
       matrix:
         control_plane: [1, 3]
         workers: [1]

--- a/config.yaml
+++ b/config.yaml
@@ -121,3 +121,7 @@ options:
     description: Allow hostpath storage provisioner on the cluster
     default: false
     type: boolean
+  rbac:
+    description: Enable Role-based access control (RBAC) authorization on the cluster
+    default: false
+    type: boolean

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -34,9 +34,6 @@ provides:
   workers:
     interface: microk8s-info
     scope: global
-  microk8s-addons:
-    interface: microk8s-addons
-    scope: container
 
 requires:
   control-plane:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -34,6 +34,9 @@ provides:
   workers:
     interface: microk8s-info
     scope: global
+  microk8s-addons:
+    interface: microk8s-addons
+    scope: container
 
 requires:
   control-plane:

--- a/src/charm.py
+++ b/src/charm.py
@@ -68,12 +68,12 @@ class MicroK8sCharm(CharmBase):
             self.framework.observe(self.on.config_changed, self.config_containerd_proxy)
             self.framework.observe(self.on.config_changed, self.config_containerd_registries)
             self.framework.observe(self.on.config_changed, self.update_status)
-            self.framework.observe(self.on.microk8s_relation_joined, self.on_install)
-            self.framework.observe(self.on.microk8s_relation_joined, self.announce_hostname)
-            self.framework.observe(self.on.microk8s_relation_changed, self.join_cluster)
-            self.framework.observe(self.on.microk8s_relation_changed, self.update_status)
-            self.framework.observe(self.on.microk8s_relation_broken, self.leave_cluster)
-            self.framework.observe(self.on.microk8s_relation_broken, self.update_status)
+            self.framework.observe(self.on.control_plane_relation_joined, self.on_install)
+            self.framework.observe(self.on.control_plane_relation_joined, self.announce_hostname)
+            self.framework.observe(self.on.control_plane_relation_changed, self.join_cluster)
+            self.framework.observe(self.on.control_plane_relation_changed, self.update_status)
+            self.framework.observe(self.on.control_plane_relation_broken, self.leave_cluster)
+            self.framework.observe(self.on.control_plane_relation_broken, self.update_status)
         else:
             self.framework.observe(self.on.remove, self.on_remove)
             self.framework.observe(self.on.upgrade_charm, self.on_upgrade)
@@ -105,17 +105,11 @@ class MicroK8sCharm(CharmBase):
             self.framework.observe(self.on.peer_relation_departed, self.update_status)
             self.framework.observe(self.on.leader_elected, self.remove_departed_nodes)
             self.framework.observe(self.on.leader_elected, self.update_status)
-            self.framework.observe(self.on.microk8s_provides_relation_joined, self.add_node)
-            self.framework.observe(
-                self.on.microk8s_provides_relation_changed, self.record_hostnames
-            )
-            self.framework.observe(
-                self.on.microk8s_provides_relation_departed, self.on_relation_departed
-            )
-            self.framework.observe(
-                self.on.microk8s_provides_relation_departed, self.remove_departed_nodes
-            )
-            self.framework.observe(self.on.microk8s_provides_relation_departed, self.update_status)
+            self.framework.observe(self.on.workers_relation_joined, self.add_node)
+            self.framework.observe(self.on.workers_relation_changed, self.record_hostnames)
+            self.framework.observe(self.on.workers_relation_departed, self.on_relation_departed)
+            self.framework.observe(self.on.workers_relation_departed, self.remove_departed_nodes)
+            self.framework.observe(self.on.workers_relation_departed, self.update_status)
 
     def on_remove(self, _: RemoveEvent):
         try:

--- a/src/charm.py
+++ b/src/charm.py
@@ -175,7 +175,7 @@ class MicroK8sCharm(CharmBase):
             return
 
         if self._state.joined:
-            LOG.info("Ensure RBAC mode is %s", self.config["rbac"])
+            self.unit.status = MaintenanceStatus("configuring RBAC")
             microk8s.wait_ready()
             microk8s.configure_rbac(self.config["rbac"])
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -192,6 +192,7 @@ class MicroK8sCharm(CharmBase):
 
         if self._state.joined and not self.config["automatic_certificate_reissue"]:
             self.unit.status = MaintenanceStatus("disabling automatic certificate reissue")
+            microk8s.wait_ready()
             microk8s.disable_cert_reissue()
 
     def config_extra_sans(self, _: ConfigChangedEvent):

--- a/src/charm.py
+++ b/src/charm.py
@@ -68,12 +68,12 @@ class MicroK8sCharm(CharmBase):
             self.framework.observe(self.on.config_changed, self.config_containerd_proxy)
             self.framework.observe(self.on.config_changed, self.config_containerd_registries)
             self.framework.observe(self.on.config_changed, self.update_status)
-            self.framework.observe(self.on.control_plane_relation_joined, self.on_install)
-            self.framework.observe(self.on.control_plane_relation_joined, self.announce_hostname)
-            self.framework.observe(self.on.control_plane_relation_changed, self.join_cluster)
-            self.framework.observe(self.on.control_plane_relation_changed, self.update_status)
-            self.framework.observe(self.on.control_plane_relation_broken, self.leave_cluster)
-            self.framework.observe(self.on.control_plane_relation_broken, self.update_status)
+            self.framework.observe(self.on.microk8s_relation_joined, self.on_install)
+            self.framework.observe(self.on.microk8s_relation_joined, self.announce_hostname)
+            self.framework.observe(self.on.microk8s_relation_changed, self.join_cluster)
+            self.framework.observe(self.on.microk8s_relation_changed, self.update_status)
+            self.framework.observe(self.on.microk8s_relation_broken, self.leave_cluster)
+            self.framework.observe(self.on.microk8s_relation_broken, self.update_status)
         else:
             self.framework.observe(self.on.remove, self.on_remove)
             self.framework.observe(self.on.upgrade_charm, self.on_upgrade)
@@ -88,6 +88,7 @@ class MicroK8sCharm(CharmBase):
             self.framework.observe(self.on.config_changed, self.config_hostpath_storage)
             self.framework.observe(self.on.config_changed, self.config_certificate_reissue)
             self.framework.observe(self.on.config_changed, self.config_extra_sans)
+            self.framework.observe(self.on.config_changed, self.config_rbac)
             self.framework.observe(self.on.config_changed, self.update_status)
             self.framework.observe(self.on.peer_relation_joined, self.add_node)
             self.framework.observe(self.on.peer_relation_joined, self.announce_hostname)
@@ -104,11 +105,17 @@ class MicroK8sCharm(CharmBase):
             self.framework.observe(self.on.peer_relation_departed, self.update_status)
             self.framework.observe(self.on.leader_elected, self.remove_departed_nodes)
             self.framework.observe(self.on.leader_elected, self.update_status)
-            self.framework.observe(self.on.workers_relation_joined, self.add_node)
-            self.framework.observe(self.on.workers_relation_changed, self.record_hostnames)
-            self.framework.observe(self.on.workers_relation_departed, self.on_relation_departed)
-            self.framework.observe(self.on.workers_relation_departed, self.remove_departed_nodes)
-            self.framework.observe(self.on.workers_relation_departed, self.update_status)
+            self.framework.observe(self.on.microk8s_provides_relation_joined, self.add_node)
+            self.framework.observe(
+                self.on.microk8s_provides_relation_changed, self.record_hostnames
+            )
+            self.framework.observe(
+                self.on.microk8s_provides_relation_departed, self.on_relation_departed
+            )
+            self.framework.observe(
+                self.on.microk8s_provides_relation_departed, self.remove_departed_nodes
+            )
+            self.framework.observe(self.on.microk8s_provides_relation_departed, self.update_status)
 
     def on_remove(self, _: RemoveEvent):
         try:
@@ -168,6 +175,15 @@ class MicroK8sCharm(CharmBase):
             self.unit.status = BlockedStatus(
                 "failed to apply containerd_custom_registries, check logs for details"
             )
+
+    def config_rbac(self, _: ConfigChangedEvent):
+        if isinstance(self.unit.status, BlockedStatus):
+            return
+
+        if self._state.joined:
+            LOG.info("Ensure RBAC mode is %s", self.config["rbac"])
+            microk8s.wait_ready()
+            microk8s.configure_rbac(self.config["rbac"])
 
     def config_hostpath_storage(self, _: ConfigChangedEvent):
         if isinstance(self.unit.status, BlockedStatus):

--- a/src/microk8s.py
+++ b/src/microk8s.py
@@ -217,7 +217,7 @@ def configure_hostpath_storage(enable: bool):
 
 def configure_rbac(enable: bool):
     """enable or disable rbac"""
-    LOG.info("Enabling RBAC" if enable else "Disabling RBAC")
+    LOG.info("Ensure RBAC is %s", enable)
     apply_launch_configuration(
         {
             "extraKubeAPIServerArgs": {

--- a/src/microk8s.py
+++ b/src/microk8s.py
@@ -213,3 +213,15 @@ def configure_hostpath_storage(enable: bool):
     else:
         LOG.info("Disable hostpath storage")
         util.ensure_call(["microk8s", "disable", "hostpath-storage"], input=b"n")
+
+
+def configure_rbac(enable: bool):
+    """enable or disable rbac"""
+    LOG.info("Enable RBAC")
+    apply_launch_configuration(
+        {
+            "extraKubeAPIServerArgs": {
+                "--authorization-mode": "Node,RBAC" if enable else "AlwaysAllow"
+            }
+        }
+    )

--- a/src/microk8s.py
+++ b/src/microk8s.py
@@ -217,7 +217,7 @@ def configure_hostpath_storage(enable: bool):
 
 def configure_rbac(enable: bool):
     """enable or disable rbac"""
-    LOG.info("Enable RBAC")
+    LOG.info("Enabling RBAC" if enable else "Disabling RBAC")
     apply_launch_configuration(
         {
             "extraKubeAPIServerArgs": {

--- a/tests/integration/test_microk8s.py
+++ b/tests/integration/test_microk8s.py
@@ -74,6 +74,7 @@ async def test_microk8s_cluster(e: OpsTest, series: str, cp_units: int, worker_u
 
     # When rbac is enabled, we can get `system:node` clusterrole successfully
     rc, stdout, stderr = await run_unit(u, "microk8s kubectl get clusterrole system:node")
+    LOG.info("stdout: %s, stderr: %s", stdout, stderr)
     assert rc == 0
 
     await e.model.wait_for_idle([a.name for a in apps], timeout=60 * 60)

--- a/tests/integration/test_microk8s.py
+++ b/tests/integration/test_microk8s.py
@@ -70,7 +70,7 @@ async def test_microk8s_cluster(e: OpsTest, series: str, cp_units: int, worker_u
             f"{application_name}:workers", f"{application_name}-worker:control-plane"
         )
 
-        await e.model.wait_for_idle(f"{application_name}-worker", timeout=60 * 60)
+        await e.model.wait_for_idle([f"{application_name}-worker"], timeout=60 * 60)
 
     await e.model.wait_for_idle([application_name], timeout=60 * 60)
 

--- a/tests/integration/test_microk8s.py
+++ b/tests/integration/test_microk8s.py
@@ -42,7 +42,6 @@ async def test_microk8s_cluster(e: OpsTest, series: str, cp_units: int, worker_u
 
     # When rbac is not enabled, we can't query for `system:node` cluster    role
     rc, stdout, stderr = await run_unit(u, "microk8s kubectl get clusterrole system:node")
-    LOG.info("RBAC output %s", (rc, stdout, stderr))
     assert rc == 1
 
     await e.model.wait_for_idle([application_name], timeout=60 * 60)
@@ -55,13 +54,9 @@ async def test_microk8s_cluster(e: OpsTest, series: str, cp_units: int, worker_u
     await e.model.wait_for_idle([application_name], timeout=60 * 60)
 
     rc, stdout, stderr = await run_unit(u, "microk8s status -w")
-    LOG.info("MicroK8s status output %s", (rc, stdout, stderr))
 
     rc, stdout, stderr = await run_unit(u, "microk8s kubectl get clusterrole system:node")
-    LOG.info("RBAC output %s", (rc, stdout, stderr))
     assert rc == 0
-
-    await e.model.wait_for_idle([application_name], timeout=60 * 60)
 
     if worker_units > 0:
         apps.append(

--- a/tests/integration/test_microk8s.py
+++ b/tests/integration/test_microk8s.py
@@ -70,6 +70,8 @@ async def test_microk8s_cluster(e: OpsTest, series: str, cp_units: int, worker_u
             f"{application_name}:workers", f"{application_name}-worker:control-plane"
         )
 
+        await e.model.wait_for_idle(f"{application_name}-worker", timeout=60 * 60)
+
     await e.model.wait_for_idle([application_name], timeout=60 * 60)
 
     # When rbac is enabled, we can get `system:node` clusterrole successfully

--- a/tests/integration/test_microk8s.py
+++ b/tests/integration/test_microk8s.py
@@ -70,7 +70,7 @@ async def test_microk8s_cluster(e: OpsTest, series: str, cp_units: int, worker_u
             f"{application_name}:workers", f"{application_name}-worker:control-plane"
         )
 
-        await e.model.wait_for_idle(f"{application_name}-worker", timeout=60 * 60)
+    await e.model.wait_for_idle([application_name], timeout=60 * 60)
 
     # When rbac is enabled, we can get `system:node` clusterrole successfully
     rc, stdout, stderr = await run_unit(u, "microk8s kubectl get clusterrole system:node")

--- a/tests/unit/test_charm_control_plane.py
+++ b/tests/unit/test_charm_control_plane.py
@@ -19,7 +19,7 @@ def test_install(e: Environment, is_leader: bool):
 
     e.util.install_required_packages.assert_called_once_with()
     e.microk8s.install.assert_called_once_with()
-    e.microk8s.wait_ready.assert_called_once_with()
+    # e.microk8s.wait_ready.assert_called_once_with()
     e.microk8s.disable_cert_reissue.assert_not_called()
 
     if not is_leader:

--- a/tests/unit/test_charm_control_plane.py
+++ b/tests/unit/test_charm_control_plane.py
@@ -19,6 +19,7 @@ def test_install(e: Environment, is_leader: bool):
 
     e.util.install_required_packages.assert_called_once_with()
     e.microk8s.install.assert_called_once_with()
+    e.microk8s.wait_ready.assert_called()
     e.microk8s.disable_cert_reissue.assert_not_called()
 
     if not is_leader:

--- a/tests/unit/test_charm_control_plane.py
+++ b/tests/unit/test_charm_control_plane.py
@@ -19,7 +19,6 @@ def test_install(e: Environment, is_leader: bool):
 
     e.util.install_required_packages.assert_called_once_with()
     e.microk8s.install.assert_called_once_with()
-    # e.microk8s.wait_ready.assert_called_once_with()
     e.microk8s.disable_cert_reissue.assert_not_called()
 
     if not is_leader:

--- a/tests/unit/test_microk8s.py
+++ b/tests/unit/test_microk8s.py
@@ -281,3 +281,14 @@ def test_microk8s_configure_hostpath_storage(
         mock.call(["microk8s", "status", "-a", "hostpath-storage"], capture_output=True),
         *expect_calls,
     ]
+
+
+@pytest.mark.parametrize("enable,method", [(True, "Node,RBAC"), (False, "AlwaysAllow")])
+@mock.patch("microk8s.apply_launch_configuration")
+def test_microk8s_configure_rbac(
+    apply_launch_configuration: mock.MagicMock, enable: bool, method: str
+):
+    microk8s.configure_rbac(enable)
+    apply_launch_configuration.assert_called_once_with(
+        {"extraKubeAPIServerArgs": {"--authorization-mode": method}}
+    )


### PR DESCRIPTION
Added additional tests in `test_microk8s_cluster` to test when rbac configs are applied. The test queries `clusterrole` before and after applying rbac config to the control plane microk8s charm.