### PR TITLE
Use edge channel for dev bundle

### DIFF
--- a/tests/dev-bundle.yaml
+++ b/tests/dev-bundle.yaml
@@ -4,16 +4,18 @@
 ---
 applications:
   microk8s:
-    charm: ../microk8s_ubuntu-20.04-amd64_ubuntu-22.04-amd64.charm
+    charm: microk8s
+    channel: edge
     scale: 1
     options:
       role: control-plane
     constraints: 'mem=4G root-disk=20G'
   microk8s-worker:
-    charm: ../microk8s_ubuntu-20.04-amd64_ubuntu-22.04-amd64.charm
+    charm: microk8s
+    channel: edge
     scale: 1
     options:
       role: worker
     constraints: 'mem=4G root-disk=20G'
 relations:
-- [microk8s:microk8s-provides, microk8s-worker:microk8s]
+- [microk8s:workers, microk8s-worker:control-plane]


### PR DESCRIPTION
### Summary

Small update to the development bundle that deploys a 2-node cluster.

