### PR TITLE
support serialize image pulls on kubelet

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -139,3 +139,9 @@ options:
       Disable certificate reissue.
     type: boolean
     default: False
+
+  kubelet_serialize_image_pulls:
+    description: >
+      Set to false to allow kubelet to pull OCI images in parallel
+    type: boolean
+    default: True


### PR DESCRIPTION
### Summary

Add a new `kubelet_serialize_image_pulls` config option (default: `true`). Set to `false` to allow kubelet to pull images in parallel.

*NOTE*: This is meant for the legacy charm, and will not be forward-ported to the new microk8s charm.