### PR TITLE
Prepare charm for release

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,39 @@
+---
+name: Bug Report
+about: Something is not working
+---
+
+<!--
+   Thank you for submitting an issue. Please fill in the template below
+   information about the bug you encountered.
+-->
+
+#### Summary
+<!-- Please explain the bug in a few short sentences -->
+
+#### What Should Happen Instead?
+<!-- Please explain what the expected behavior is -->
+
+#### Reproduction Steps
+<!-- Are you able to consistently reproduce the issue? Please add a list of steps that lead to the bug. -->
+
+1. ...
+2. ...
+
+#### Environment
+<!-- What is the environment where the bug occurs? -->
+
+**MicroK8s charm track**: latest/edge
+**Juju version**: 3.1
+**Cloud**: LXD/MaaS/OpenStack/AWS/Azure/...
+
+#### Additional info, logs
+<!-- Please attach the output of `juju status`, `juju debug-log --replay`, or `juju export-bundle` if needed -->
+
+#### Can you suggest a fix?
+<!-- (This section is optional). How do you propose that the issue be fixed? -->
+
+#### Are you interested in contributing with a fix?
+<!-- yes/no, or @mention maintainers. Community contributions are welcome. -->
+
+<!-- Thank you for making MicroK8s better -->

--- a/.github/ISSUE_TEMPLATE/create_release_branch.md
+++ b/.github/ISSUE_TEMPLATE/create_release_branch.md
@@ -1,0 +1,75 @@
+---
+name: [Runbook] Create release branch
+about: Create a new branch for a new stable Kubernetes release
+---
+
+#### Summary
+
+Make sure to follow the steps below and ensure all actions are completed and signed-off by one team member.
+
+#### Information
+
+<!-- Replace with the version to create the branch for, e.g. 1.28 -->
+- **MicroK8s version**: 1.xx
+
+<!-- Set this to the name of the person responsible for running the release tasks, e.g. @neoaggelos -->
+- **Owner**:
+
+<!-- Set this to the name of the team-member that will sign-off the tasks -->
+- **Reviewer**:
+
+<!-- Link to PR to initialize the release branch (see below) -->
+- **PR**:
+
+#### Actions
+
+The steps are to be followed in-order, each task must be completed by the person specified in **bold**. Do not perform any steps unless all previous ones have been signed-off. The **Reviewer** closes the issue once all steps are complete.
+
+- [ ] **Owner**: Add the assignee and reviewer as assignees to the GitHub issue
+- [ ] **Owner**: Ensure that you are part of the ["microk8s developers" team](https://launchpad.net/~microk8s-dev)
+- [ ] **Owner**: Request a new `1.xx` CharmHub track for the `microk8s` charm.
+  - #### Email template
+
+    **To:** snap-store-admins AT canonical.com
+
+    **Cc:** k8s-crew AT canonical.com
+
+    **Subject:** [k8s-crew] Track request for MicroK8s charm
+
+    **Body:**
+
+    Hi admins, please open a new track `1.xx` for the `microk8s` charm.
+
+    Thank you,
+    $name
+- [ ] **Owner**: Create `release-1.xx` branch from latest `master`
+  - `git checkout master`
+  - `git pull`
+  - `git checkout -b release-1.xx`
+  - `git push origin release-1.xx`
+- [ ] **Reviewer**: Ensure `release-1.xx` branch is based on latest changes on master at the time of the release cut.
+- [ ] **Owner**: Create PR to initialize `release-1.xx` branch:
+  - [ ] Update branch from `master` to `release-1.xx` in [.github/workflows/cla-check.yml](../workflows/cla-check.yml)
+  - [ ] Update branch from `master` to `release-1.xx` in [.github/workflows/python.yml](../workflows/python.yml)
+  - [ ] Update branch from `master` to `release-1.xx` in [.github/workflows/test.yml](../workflows/test.yml)
+  - [ ] Update `cancel-in-progress` from `refs/heads/master` to `refs/heads/release-1.xx` in [.github/workflows/test.yml](../workflows/test.yml)
+  - [ ] Update `SNAP_CHANNEL` to `1.xx` in [src/charm_config.py](../../src/charm_config.py)
+  - [ ] Update `*_CHANNEL` in [tests/integration/config.py](../../tests/integration/config.py). Kubernetes charms should use `1.xx/edge`, others should use `edge` unless there has been a breaking change.
+  - [ ] `git commit -m 'Release 1.xx'`
+  - [ ] Create PR with the changes and request review from **Reviewer**. Make sure to update the issue `Information` section with a link to the PR.
+- [ ] **Reviewer**: Review and merge PR to initialize branch.
+- [ ] **Owner**: Create launchpad builders for `release-1.xx`
+  - [ ] Go to https://code.launchpad.net/~microk8s-dev/charm-microk8s/+git/charm-microk8s and do **Import now** to pick up all latest changes.
+  - [ ] Under **Branches**, select `release-1.xx`, then **Create charm recipe**
+  - [ ] Set **Charm recipe name** to `microk8s-1.xx`
+  - [ ] Enable **Automatically build when branch changes**
+  - [ ] Enable **Automatically upload to store**
+  - [ ] Set **Registered store name** to `microk8s`
+  - [ ] In **Store Channels**, set **Track** to `1.xx` and **Risk** to `edge`. Leave **Branch** empty
+  - [ ] Click **Create charm recipe** at the bottom of the page. You will be asked to authenticate with CharmHub so that LaunchPad can automatically push the charm on each build.
+- [ ] **Reviewer**: Ensure charm recipe for `release-1.xx` is created
+  - List of recipes https://code.launchpad.net/~microk8s-dev/charm-microk8s/+git/charm-microk8s/+charm-recipes
+
+#### After release
+
+**Owner** follows up with the **Reviewer** and team about things to improve around the process.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,21 @@
+---
+name: Feature Request
+about: Suggest a new feature
+---
+
+<!--
+   Thank you for submitting a feature request. Please fill the template below
+   with more details.
+-->
+
+#### Summary
+<!-- Please explain the feature request in a few short sentences. -->
+
+#### Why is this important?
+<!-- Please explain the motivation, how it will be used, etc. -->
+
+#### Are you interested in contributing to this feature?
+<!-- yes/no, or @mention maintainers. -->
+
+
+<!-- Thank you for making MicroK8s better -->

--- a/.github/workflows/cla-check.yml
+++ b/.github/workflows/cla-check.yml
@@ -2,7 +2,7 @@ name: CLA
 
 on:
   pull_request:
-    branches: [master, default]
+    branches: [master]
 
 jobs:
   check:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,8 +2,7 @@ name: Integration Tests
 
 on:
   push:
-    branches:
-      - master
+    branches: [master]
   pull_request:
 
 concurrency:

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,27 @@
+# MicroK8s Charm Releases
+
+## Charm branches
+
+Feature development happens in `master`. When a new Kubernetes version `1.xx` is in RC or GA, create a new GitHub issue using the `[Runbook] Create release branch` and follow the steps.
+
+## Tracks and channels
+
+This section describes which channels and tracks are in-use by the MicroK8s charm.
+
+### CharmHub Tracks
+
+At any given point, the following table describes which MicroK8s charm tracks are maintained and in-use:
+
+| CharmHub Track | Snap channel | Charm source branch | Description                                                                                     |
+| -------------- | ------------ | ------------------- | ----------------------------------------------------------------------------------------------- |
+| latest         | latest/edge  | master              | Built from latest `master` and installs MicroK8s from latest/edge. Not meant for production use |
+| 1.29           | 1.29/stable  | release-1.29        | Built from branch `release-1.29`, deploys MicroK8s 1.29 clusters                                |
+| 1.28           | 1.28/stable  | release-1.28        | Built from branch `release-1.28`, deploys MicroK8s 1.28 clusters                                |
+
+### CharmHub Channels
+
+| CharmHub channel | Description                        | Release when                                            |
+| ---------------- | ---------------------------------- | ------------------------------------------------------- |
+| edge             | Built from branch `release-$track` | On every commit after all CI tests pass                 |
+| candidate        | Promoted from `edge`               | `edge` is ready for new release                         |
+| stable           | Promoted from `candidate`          | `candidate` is tested and is blessed for production use |


### PR DESCRIPTION
### Summary

Prepare charm for release

### Changes

- Add GitHub issue templates for bug reports and feature requests
- Update MetalLB tests to use the new https://charmhub.io/metallb charm
- For latest master, install microk8s from latest/edge (will be set for stable release branches)
- Document charm channels and tracks
- Add runbook for creating stable version branches