### PR TITLE
Channel config and use latest metallb charm for integration tests

### DIFF
--- a/tests/integration/config.py
+++ b/tests/integration/config.py
@@ -44,21 +44,29 @@ MK8S_PROXY = os.getenv("MK8S_PROXY")
 #   - ''                        <-- do not configure proxy
 MK8S_NO_PROXY = os.getenv("MK8S_NO_PROXY")
 
-# MK8S_METALLB_SPEAKER_CHARM is the metallb-speaker charm for the MetalLB integration tests.
-#   - 'ch:metallb-speaker'      <-- install charm 'metallb-speaker' from CharmHub
-MK8S_METALLB_SPEAKER_CHARM = os.getenv("MK8S_METALLB_SPEAKER_CHARM", "ch:metallb-speaker")
+# MK8S_METALLB_CHARM is the metallb charm for the MetalLB integration tests.
+#   - 'ch:metallb'              <-- install charm 'metallb' from CharmHub
+MK8S_METALLB_CHARM = os.getenv("MK8S_METALLB_CHARM", "ch:metallb")
 
-# MK8S_METALLB_CONTROLLER_CHARM is the metallb-controller charm for the MetalLB integration tests.
-#   - 'ch:metallb-controller'   <-- install charm 'metallb-controller' from CharmHub
-MK8S_METALLB_CONTROLLER_CHARM = os.getenv("MK8S_METALLB_CONTROLLER_CHARM", "ch:metallb-controller")
+# MK8S_METALLB_CHANNEL is the CharmHub channel to use for the metallb charm.
+#   - 'edge'                    <-- install charm from 'edge' channel
+MK8S_METALLB_CHANNEL = os.getenv("MK8S_METALLB_CHANNEL", "edge")
 
 # MK8S_TRAEFIK_K8S_CHARM is the traefik-k8s ingress charm for the respective integration tests.
 #   - 'ch:traefik-k8s'          <-- install charm 'traefik-k8s' from CharmHub
 MK8S_TRAEFIK_K8S_CHARM = os.getenv("MK8S_TRAEFIK_K8S_CHARM", "ch:traefik-k8s")
 
+# MK8S_TRAEFIK_K8S_CHANNEL is the CharmHub channel to use for the traefik-k8s charm.
+#   - 'edge'                    <-- install charm from 'edge' channel
+MK8S_TRAEFIK_K8S_CHANNEL = os.getenv("MK8S_TRAEFIK_K8S_CHANNEL", "edge")
+
 # MK8S_HELLO_KUBECON_CHARM is the hello-kubecon charm for the ingress integration tests.
 #   - 'ch:hello-kubecon'        <-- install charm 'hello-kubecon' from CharmHub
 MK8S_HELLO_KUBECON_CHARM = os.getenv("MK8S_HELLO_KUBECON_CHARM", "ch:hello-kubecon")
+
+# MK8S_HELLO_KUBECON_CHANNEL is the CharmHub channel to use for the hello-kubecon charm.
+#   - 'edge'                    <-- install charm from 'edge' channel
+MK8S_HELLO_KUBECON_CHANNEL = os.getenv("MK8S_HELLO_KUBECON_CHANNEL", "edge")
 
 # MK8S_GRAFANA_AGENT_CHARM is the grafana-agent charm for the observability integration tests.
 #   - 'ch:grafana-agent'       <-- install charm 'grafana-agent' from CharmHub


### PR DESCRIPTION
### Summary

- Use the https://charmhub.io/metallb charm for the integration tests
- Make use of configuration for the channels of all charms used in our integration tests

Split from #93 