### PR TITLE
Add coreDNS integrations 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -181,3 +181,53 @@ jobs:
         with:
           name: Observability - juju ${{ matrix.juju }}
           path: artifacts/
+
+  test-coredns:
+    name: CoreDNS - juju ${{ matrix.juju }}
+    runs-on: ubuntu-latest
+    needs: build
+    strategy:
+      fail-fast: true
+      matrix:
+        juju: [2.9, 3.1]
+    steps:
+      - name: Checking out repo
+        uses: actions/checkout@v3.5.2
+      # - name: Setup tmate session
+      #   uses: mxschmitt/action-tmate@v3
+      - name: Configure pytest-operator
+        uses: charmed-kubernetes/actions-operator@main
+        with:
+          provider: lxd
+          lxd-channel: 5.0/stable
+          juju-channel: ${{ matrix.juju }}/stable
+      - name: Add user to lxd group
+        run: sudo usermod -a -G lxd $USER
+      - name: Fetch charm
+        uses: actions/download-artifact@v3.0.2
+        with:
+          name: microk8s.charm
+          path: build
+      - name: Install tox
+        run: |
+          pip3 install tox
+      - name: Run integration tests
+        run: |
+          juju add-model testing
+          export MK8S_SERIES='${{ matrix.series }}'
+          export MK8S_CHARM=./build/microk8s.charm
+          export MK8S_CHARM_CHANNEL=''
+          sg lxd -c 'tox -e integration-${{ matrix.juju }} -- --model testing -k test_coredns'
+      - name: Retrieve artifacts
+        if: always()
+        run: |
+          mkdir artifacts
+          juju debug-log -m testing --replay > artifacts/juju.log
+          juju status -m testing --format yaml > artifacts/juju.yaml
+          cp pytest.log artifacts/pytest.log
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v3.1.2
+        with:
+          name: CoreDNS - juju ${{ matrix.juju }}
+          path: artifacts/

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -44,3 +44,6 @@ requires:
     interface: microk8s-info
     scope: global
     limit: 1
+  dns:
+    interface: kube-dns
+    limit: 1

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,4 @@
 coverage[toml]==7.2.5
 pytest==7.3.1
 
-pytest-operator==0.27.0
+pytest-operator==0.29.0

--- a/src/microk8s.py
+++ b/src/microk8s.py
@@ -231,3 +231,16 @@ def write_local_kubeconfig():
     """write kubeconfig file for the cluster"""
     p = util.ensure_call(["microk8s", "config"], capture_output=True)
     util.ensure_file(Path("/root/.kube/config"), p.stdout.decode(), 0o600, 0, 0)
+
+
+def configure_dns(ip: str, domain: str):
+    """update kubelet dns configuration"""
+    LOG.info("Use DNS %s (domain %s)", ip, domain)
+    apply_launch_configuration(
+        {
+            "extraKubeletArgs": {
+                "--cluster-dns": ip,
+                "--cluster-domain": domain,
+            }
+        }
+    )

--- a/tests/integration/config.py
+++ b/tests/integration/config.py
@@ -75,3 +75,11 @@ MK8S_GRAFANA_AGENT_CHARM = os.getenv("MK8S_GRAFANA_AGENT_CHARM", "ch:grafana-age
 # MK8S_GRAFANA_AGENT_CHANNEL is the CharmHub channel to use for the grafana-agent charm.
 #   - 'edge'                   <-- install charm from 'edge' channel
 MK8S_GRAFANA_AGENT_CHANNEL = os.getenv("MK8S_GRAFANA_AGENT_CHANNEL", "edge")
+
+# MK8S_COREDNS_CHARM is the core-dns charm for integration tests.
+#   - 'ch:coredns'              <-- install charm 'coredns' from CharmHub
+MK8S_COREDNS_CHARM = os.getenv("MK8S_COREDNS_CHARM", "ch:coredns")
+
+# MK8S_COREDNS_CHANNEL is the CharmHub channel to use for the core-dns charm.
+#   - 'edge'                    <-- install charm from 'edge' channel
+MK8S_COREDNS_CHANNEL = os.getenv("MK8S_COREDNS_CHANNEL", "edge")

--- a/tests/integration/test_coredns.py
+++ b/tests/integration/test_coredns.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+#
+# Copyright 2023 Canonical, Ltd.
+#
+
+import logging
+
+import config
+import pytest
+from conftest import microk8s_kubernetes_cloud_and_model, run_unit
+from juju.application import Application
+from juju.unit import Unit
+from pytest_operator.plugin import OpsTest
+
+LOG = logging.getLogger(__name__)
+
+DNS_TEST = "microk8s kubectl run -it --rm debug --image=busybox:1.28.4 --restart=Never -- nslookup google.com"
+
+
+@pytest.mark.abort_on_fail
+async def test_core_dns(e: OpsTest):
+    # deploy microk8s
+    if "microk8s" not in e.model.applications:
+        await e.model.deploy(
+            config.MK8S_CHARM,
+            application_name="microk8s",
+            config={"hostpath_storage": "true"},
+            channel=config.MK8S_CHARM_CHANNEL,
+            constraints=config.MK8S_CONSTRAINTS,
+        )
+        await e.model.wait_for_idle(["microk8s"])
+
+    app: Application = e.model.applications["microk8s"]
+    unit: Unit = app.units[0]
+
+    # bootstrap a juju cloud on the deployed microk8s
+    async with microk8s_kubernetes_cloud_and_model(e, "microk8s") as (k8s_model, model_name):
+        with e.model_context(k8s_model):
+            LOG.info("Deploy CoreDNS")
+            await e.model.deploy(
+                config.MK8S_COREDNS_CHARM,
+                application_name="coredns",
+                channel=config.MK8S_COREDNS_CHANNEL,
+                trust=True,
+            )
+            await e.model.wait_for_idle(["coredns"])
+
+            LOG.info("Create offer for coredns:dns-provider endpoint")
+            await e.model.create_offer("coredns:dns-provider", "coredns")
+
+        try:
+            LOG.info("Consume coredns:dns-provider and relate with microk8s")
+            await e.model.consume(f"admin/{model_name}.coredns", "coredns")
+            await e.model.add_relation("microk8s", "coredns")
+            await e.model.wait_for_idle(["microk8s"])
+
+            with e.model_context(k8s_model):
+                await e.model.wait_for_idle(["coredns"])
+
+            for _ in range(10):
+                rc, stdout, stderr = await run_unit(unit, DNS_TEST)
+                LOG.info("Verify the pod dns resolution %s", (rc, stdout, stderr))
+                if rc == 0:
+                    break
+
+            assert rc == 0, "Failed to resolve DNS in 10 tries"
+
+        finally:
+            await app.remove_relation("dns", "coredns")
+            await e.model.remove_saas("coredns")
+            await e.model.wait_for_idle(["microk8s"])

--- a/tests/unit/test_microk8s.py
+++ b/tests/unit/test_microk8s.py
@@ -303,3 +303,12 @@ def test_microk8s_write_local_kubeconfig(ensure_file: mock.MagicMock, ensure_cal
     ensure_file.assert_called_once_with(
         Path("/root/.kube/config"), ensure_call.return_value.stdout.decode.return_value, 0o600, 0, 0
     )
+
+
+@mock.patch("microk8s.apply_launch_configuration")
+def test_microk8s_configure_dns(apply_launch_configuration: mock.MagicMock):
+    microk8s.configure_dns("fakeip", "fakedomain")
+
+    apply_launch_configuration.assert_called_once_with(
+        {"extraKubeletArgs": {"--cluster-dns": "fakeip", "--cluster-domain": "fakedomain"}}
+    )


### PR DESCRIPTION
### Summary
Add integration support for the coredns charm.

### Changes
- Extended charm functionality to handle events in case of DNS switch.
- Added unit and integration tests for coredns.
- Added the new tests in GitHub workflow.
