### PR TITLE
Write kubeconfig on control plane nodes

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -244,6 +244,9 @@ class MicroK8sCharm(CharmBase):
             time.sleep(2)
             self.unit.status = microk8s.get_unit_status(socket.gethostname())
 
+        if self._state.role != "worker":
+            microk8s.write_local_kubeconfig()
+
     def record_hostnames(self, event: Union[RelationChangedEvent, RelationJoinedEvent]):
         for unit in event.relation.units:
             hostname = event.relation.data[unit].get("hostname")

--- a/src/microk8s.py
+++ b/src/microk8s.py
@@ -225,3 +225,9 @@ def configure_rbac(enable: bool):
             }
         }
     )
+
+
+def write_local_kubeconfig():
+    """write kubeconfig file for the cluster"""
+    p = util.ensure_call(["microk8s", "config"], capture_output=True)
+    util.ensure_file(Path("/root/.kube/config"), p.stdout.decode(), 0o600, 0, 0)

--- a/tests/unit/test_charm_worker.py
+++ b/tests/unit/test_charm_worker.py
@@ -15,6 +15,7 @@ def test_install(e: Environment):
     e.util.install_required_packages.assert_called_once_with()
     e.microk8s.install.assert_called_once_with()
     e.microk8s.wait_ready.assert_called_once_with()
+    e.microk8s.write_local_kubeconfig.assert_not_called()
 
     assert not e.harness.charm.model.unit.opened_ports()
 
@@ -54,6 +55,7 @@ def test_control_plane_relation(e: Environment, is_leader: bool):
     rel_id = e.harness.add_relation("control-plane", "microk8s-cp")
     e.harness.add_relation_unit(rel_id, "microk8s-cp/0")
     e.microk8s.install.assert_called_once_with()
+    e.microk8s.write_local_kubeconfig.assert_not_called()
 
 
 def test_control_plane_relation_invalid(e: Environment):

--- a/tests/unit/test_microk8s.py
+++ b/tests/unit/test_microk8s.py
@@ -292,3 +292,14 @@ def test_microk8s_configure_rbac(
     apply_launch_configuration.assert_called_once_with(
         {"extraKubeAPIServerArgs": {"--authorization-mode": method}}
     )
+
+
+@mock.patch("util.ensure_call", autospec=True)
+@mock.patch("util.ensure_file", autospec=True)
+def test_microk8s_write_local_kubeconfig(ensure_file: mock.MagicMock, ensure_call: mock.MagicMock):
+    microk8s.write_local_kubeconfig()
+
+    ensure_call.assert_called_once_with(["microk8s", "config"], capture_output=True)
+    ensure_file.assert_called_once_with(
+        Path("/root/.kube/config"), ensure_call.return_value.stdout.decode.return_value, 0o600, 0, 0
+    )


### PR DESCRIPTION
### Summary

On control plane nodes, ensure `/root/.kube/config` is a valid kubeconfig file, as expected by quite a few charms.