### PR TITLE
Set the Kubernetes version as workload version

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -269,6 +269,10 @@ class MicroK8sCharm(CharmBase):
             time.sleep(2)
             self.unit.status = microk8s.get_unit_status(socket.gethostname())
 
+        k8s_version = microk8s.get_kubernetes_version()
+        if k8s_version:
+            self.unit.set_workload_version(k8s_version)
+
         if self._state.role != "worker":
             microk8s.write_local_kubeconfig()
 

--- a/src/microk8s.py
+++ b/src/microk8s.py
@@ -250,7 +250,11 @@ def get_kubernetes_version() -> str:
     """retrieve version of kubernetes running on the unit"""
     try:
         p = util.run(["microk8s", "version"], capture_output=True)
-        return p.stdout.decode().split(" ")[1]
+        version = p.stdout.decode().split(" ")[1]
+        if version.startswith("v"):
+            version = version[1:]
+
+        return version
     except (subprocess.CalledProcessError, ValueError, IndexError, TypeError) as e:
         LOG.warning("could not retrieve microk8s version: %s", e)
         return None

--- a/src/microk8s.py
+++ b/src/microk8s.py
@@ -244,3 +244,13 @@ def configure_dns(ip: str, domain: str):
             }
         }
     )
+
+
+def get_kubernetes_version() -> str:
+    """retrieve version of kubernetes running on the unit"""
+    try:
+        p = util.run(["microk8s", "version"], capture_output=True)
+        return p.stdout.decode().split(" ")[1]
+    except (subprocess.CalledProcessError, ValueError, IndexError, TypeError) as e:
+        LOG.warning("could not retrieve microk8s version: %s", e)
+        return None

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -6,6 +6,7 @@ from unittest import mock
 
 import ops.testing
 import pytest
+from ops.model import ActiveStatus
 
 from charm import MicroK8sCharm
 
@@ -47,7 +48,13 @@ def e():
     for k, v in patchers.items():
         mocks[k] = v.start()
 
-    yield Environment(harness, **mocks)
+    e = Environment(harness, **mocks)
+
+    # default mocks
+    e.microk8s.get_unit_status.return_value = ActiveStatus("fakestatus")
+    e.gethostname.return_value = "fakehostname"
+
+    yield e
 
     harness.cleanup()
     for k, v in patchers.items():

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -51,6 +51,7 @@ def e():
     e = Environment(harness, **mocks)
 
     # default mocks
+    e.microk8s.get_kubernetes_version.return_value = "fakeversion"
     e.microk8s.get_unit_status.return_value = ActiveStatus("fakestatus")
     e.gethostname.return_value = "fakehostname"
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -76,20 +76,28 @@ def test_remove(e: Environment):
 
 def test_update_status(e: Environment):
     e.microk8s.get_unit_status.return_value = ops.model.ActiveStatus("fakestatus2")
+    e.microk8s.get_kubernetes_version.return_value = None
+
     e.harness.begin_with_initial_hooks()
 
     e.microk8s.get_unit_status.assert_not_called()
+    e.microk8s.get_kubernetes_version.assert_not_called()
 
     e.harness.charm.on.update_status.emit()
     e.microk8s.get_unit_status.assert_not_called()
+    e.microk8s.get_kubernetes_version.assert_not_called()
 
     e.harness.charm._state.joined = True
     e.harness.charm.on.update_status.emit()
     e.microk8s.get_unit_status.assert_called_once_with(e.gethostname.return_value)
+    e.microk8s.get_kubernetes_version.assert_called_once_with()
     assert e.harness.charm.unit.status == ops.model.ActiveStatus("fakestatus2")
+    assert e.harness.charm.unit._backend._workload_version is None
 
     # reset
     e.microk8s.get_unit_status.reset_mock()
+    e.microk8s.get_kubernetes_version.reset_mock()
+    e.microk8s.get_kubernetes_version.return_value = "fakeversion"
 
     # test retry until active status
     e.microk8s.get_unit_status.side_effect = [
@@ -100,6 +108,7 @@ def test_update_status(e: Environment):
 
     assert e.microk8s.get_unit_status.mock_calls == [mock.call(e.gethostname.return_value)] * 2
     assert e.harness.charm.unit.status == ops.model.ActiveStatus("fakestatus3")
+    assert e.harness.charm.unit._backend._workload_version == "fakeversion"
 
 
 @pytest.mark.parametrize("role", ["", "control-plane"])

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -105,8 +105,6 @@ def test_update_status(e: Environment):
 @pytest.mark.parametrize("role", ["", "control-plane"])
 @pytest.mark.parametrize("has_joined", [False, True])
 def test_config_disable_cert_reissue(e: Environment, role: str, has_joined: bool):
-    e.microk8s.get_unit_status.return_value = ops.model.ActiveStatus("fakestatus")
-
     e.harness.update_config({"role": role, "automatic_certificate_reissue": True})
     e.harness.set_leader(has_joined)
     e.harness.begin_with_initial_hooks()
@@ -125,8 +123,6 @@ def test_config_disable_cert_reissue(e: Environment, role: str, has_joined: bool
 @pytest.mark.parametrize("role", ["", "control-plane"])
 @pytest.mark.parametrize("has_joined", [False, True])
 def test_config_extra_sans(e: Environment, role: str, has_joined: bool):
-    e.microk8s.get_unit_status.return_value = ops.model.ActiveStatus("fakestatus")
-
     e.harness.update_config({"role": role, "extra_sans": ""})
     e.harness.set_leader(has_joined)
     e.harness.begin_with_initial_hooks()
@@ -144,8 +140,6 @@ def test_config_extra_sans(e: Environment, role: str, has_joined: bool):
 
 @pytest.mark.parametrize("role", ["", "control-plane", "worker"])
 def test_charm_upgrade(e: Environment, role: str):
-    e.microk8s.get_unit_status.return_value = ops.model.ActiveStatus("fakestatus")
-
     e.harness.update_config({"role": role, "automatic_certificate_reissue": True})
     e.harness.begin_with_initial_hooks()
 
@@ -157,8 +151,6 @@ def test_charm_upgrade(e: Environment, role: str):
 @pytest.mark.parametrize("role", ["", "control-plane"])
 @pytest.mark.parametrize("has_joined", [False, True])
 def test_config_containerd_custom_registries(e: Environment, role: str, has_joined: bool):
-    e.microk8s.get_unit_status.return_value = ops.model.ActiveStatus("fakestatus")
-
     e.harness.update_config({"role": role, "containerd_custom_registries": "[]"})
     e.harness.set_leader(has_joined)
     e.harness.begin_with_initial_hooks()
@@ -203,8 +195,6 @@ def test_config_containerd_custom_registries(e: Environment, role: str, has_join
 @pytest.mark.parametrize("is_leader", [False, True])
 @pytest.mark.parametrize("has_joined", [False, True])
 def test_config_hostpath_storage(e: Environment, role: str, is_leader: bool, has_joined: bool):
-    e.microk8s.get_unit_status.return_value = ops.model.ActiveStatus("fakestatus")
-
     e.harness.update_config({"role": role})
     e.harness.set_leader(is_leader)
     e.harness.begin_with_initial_hooks()
@@ -232,8 +222,6 @@ def test_config_hostpath_storage(e: Environment, role: str, is_leader: bool, has
 @pytest.mark.parametrize("is_leader", [False, True])
 @pytest.mark.parametrize("has_joined", [False, True])
 def test_config_rbac(e: Environment, role: str, is_leader: bool, has_joined: bool):
-    e.microk8s.get_unit_status.return_value = ops.model.ActiveStatus("fakestatus")
-
     e.harness.update_config({"role": role})
     e.harness.set_leader(is_leader)
     e.harness.begin_with_initial_hooks()
@@ -261,8 +249,6 @@ def test_config_rbac(e: Environment, role: str, is_leader: bool, has_joined: boo
 @pytest.mark.parametrize("is_leader", [False, True])
 @pytest.mark.parametrize("has_joined", [False, True])
 def test_relation_dns(e: Environment, role: str, is_leader: bool, has_joined: bool):
-    e.microk8s.get_unit_status.return_value = ops.model.ActiveStatus("fakestatus")
-
     e.harness.update_config({"role": role})
     e.harness.set_leader(is_leader)
     e.harness.begin_with_initial_hooks()

--- a/tests/unit/test_charm_control_plane.py
+++ b/tests/unit/test_charm_control_plane.py
@@ -12,8 +12,6 @@ from conftest import Environment
 
 @pytest.mark.parametrize("is_leader", [True, False])
 def test_install(e: Environment, is_leader: bool):
-    e.microk8s.get_unit_status.return_value = ops.model.ActiveStatus("fakestatus")
-
     e.harness.update_config({"role": "control-plane"})
     e.harness.set_leader(is_leader)
     e.harness.begin_with_initial_hooks()
@@ -40,8 +38,6 @@ def test_install(e: Environment, is_leader: bool):
 
 def test_leader_peer_relation(e: Environment):
     e.microk8s.add_node.return_value = "01010101010101010101010101010101"
-    e.microk8s.get_unit_status.return_value = ops.model.ActiveStatus("fakestatus")
-    e.gethostname.return_value = "fakehostname"
 
     e.harness.add_network("10.10.10.10")
     e.harness.update_config({"role": "control-plane"})
@@ -62,8 +58,6 @@ def test_leader_peer_relation(e: Environment):
 
 
 def test_leader_peer_relation_leave(e: Environment):
-    e.microk8s.get_unit_status.return_value = ops.model.ActiveStatus("fakestatus")
-    e.gethostname.return_value = "fakehostname"
     fakeaddress = "10.10.10.10"
 
     e.harness.add_network(fakeaddress)
@@ -90,8 +84,6 @@ def test_leader_peer_relation_leave(e: Environment):
 
 def test_leader_control_plane_relation(e: Environment):
     e.microk8s.add_node.return_value = "01010101010101010101010101010101"
-    e.microk8s.get_unit_status.return_value = ops.model.ActiveStatus("fakestatus")
-    e.gethostname.return_value = "fakehostname"
 
     e.harness.add_network("10.10.10.10")
     e.harness.update_config({"role": "control-plane"})
@@ -114,9 +106,6 @@ def test_leader_control_plane_relation(e: Environment):
 
 
 def test_follower_peer_relation(e: Environment):
-    e.microk8s.get_unit_status.return_value = ops.model.ActiveStatus("fakestatus")
-    e.gethostname.return_value = "fakehostname"
-
     e.harness.update_config({"role": "control-plane"})
     e.harness.set_leader(True)
     e.harness.begin_with_initial_hooks()
@@ -136,8 +125,6 @@ def test_follower_peer_relation(e: Environment):
 
 
 def test_follower_control_plane_relation(e: Environment):
-    e.microk8s.get_unit_status.return_value = ops.model.ActiveStatus("fakestatus")
-    e.gethostname.return_value = "fakehostname"
     e.harness.update_config({"role": "control-plane"})
     e.harness.set_leader(True)
     e.harness.begin_with_initial_hooks()
@@ -157,9 +144,6 @@ def test_follower_control_plane_relation(e: Environment):
 
 
 def test_follower_retrieve_join_url(e: Environment):
-    e.microk8s.get_unit_status.return_value = ops.model.ActiveStatus("fakestatus")
-    e.gethostname.return_value = "fakehostname"
-
     e.harness.update_config({"role": "control-plane", "automatic_certificate_reissue": False})
     e.harness.set_leader(False)
     e.harness.begin_with_initial_hooks()
@@ -184,9 +168,6 @@ def test_follower_retrieve_join_url(e: Environment):
 
 @pytest.mark.parametrize("become_leader", [True, False])
 def test_follower_become_leader_remove_departing_nodes(e: Environment, become_leader: bool):
-    e.microk8s.get_unit_status.return_value = ops.model.ActiveStatus("fakestatus")
-    e.gethostname.return_value = "fakehostname"
-
     e.harness.update_config({"role": "control-plane"})
     e.harness.set_leader(False)
     e.harness.begin_with_initial_hooks()
@@ -220,9 +201,6 @@ def test_follower_become_leader_remove_departing_nodes(e: Environment, become_le
 
 @pytest.mark.parametrize("become_leader", [True, False])
 def test_follower_become_leader_remove_already_departed_nodes(e: Environment, become_leader: bool):
-    e.microk8s.get_unit_status.return_value = ops.model.ActiveStatus("fakestatus")
-    e.gethostname.return_value = "fakehostname"
-
     e.harness.update_config({"role": "control-plane"})
     e.harness.set_leader(False)
     e.harness.begin_with_initial_hooks()
@@ -251,9 +229,7 @@ def test_follower_become_leader_remove_already_departed_nodes(e: Environment, be
 @pytest.mark.parametrize("is_leader", [False, True])
 @pytest.mark.parametrize("has_joined", [False, True])
 def test_build_scrape_configs(e: Environment, role: str, is_leader: bool, has_joined: bool):
-    e.gethostname.return_value = "fakehostname"
     e.metrics.get_tls_auth.return_value = ("fakecrt", "fakekey")
-    e.microk8s.get_unit_status.return_value = ops.model.ActiveStatus("fakestatus")
 
     e.harness.update_config({"role": role})
     e.harness.set_leader(is_leader)
@@ -286,8 +262,6 @@ def test_build_scrape_configs(e: Environment, role: str, is_leader: bool, has_jo
 
 @pytest.mark.parametrize("is_leader", (True, False))
 def test_cos_agent_relation(e: Environment, is_leader: bool):
-    e.microk8s.get_unit_status.return_value = ops.model.ActiveStatus("fakestatus")
-    e.gethostname.return_value = "fakehostname"
     e.metrics.build_scrape_jobs.return_value = [{"job_name": "fakejob"}]
     e.metrics.get_tls_auth.return_value = ("fakecrt", "fakekey")
 

--- a/tests/unit/test_charm_worker.py
+++ b/tests/unit/test_charm_worker.py
@@ -24,9 +24,6 @@ def test_install(e: Environment):
 
 @pytest.mark.parametrize("is_leader", [True, False])
 def test_control_plane_relation(e: Environment, is_leader: bool):
-    e.microk8s.get_unit_status.return_value = ops.model.ActiveStatus("fakestatus")
-    e.gethostname.return_value = "fakehostname"
-
     e.harness.update_config({"role": "worker"})
     e.harness.set_leader(is_leader)
     e.harness.begin_with_initial_hooks()
@@ -59,9 +56,6 @@ def test_control_plane_relation(e: Environment, is_leader: bool):
 
 
 def test_control_plane_relation_invalid(e: Environment):
-    e.microk8s.get_unit_status.return_value = ops.model.ActiveStatus("fakestatus")
-    e.gethostname.return_value = "fakehostname"
-
     e.harness.update_config({"role": "worker"})
     e.harness.begin_with_initial_hooks()
     assert isinstance(e.harness.charm.model.unit.status, ops.model.WaitingStatus)
@@ -84,9 +78,6 @@ def test_control_plane_relation_invalid(e: Environment):
 
 @pytest.mark.parametrize("is_leader", [True, False])
 def test_control_plane_relation_departed(e: Environment, is_leader: bool):
-    e.microk8s.get_unit_status.return_value = ops.model.ActiveStatus("fakestatus")
-    e.gethostname.return_value = "fakehostname"
-
     e.harness.update_config({"role": "worker"})
     e.harness.set_leader(is_leader)
     e.harness.begin_with_initial_hooks()
@@ -117,9 +108,6 @@ def test_control_plane_relation_departed(e: Environment, is_leader: bool):
 @pytest.mark.parametrize("is_leader", [False, True])
 @pytest.mark.parametrize("has_joined", [False, True])
 def test_build_scrape_configs(e: Environment, role: str, is_leader: bool, has_joined: bool):
-    e.gethostname.return_value = "fakehostname"
-    e.microk8s.get_unit_status.return_value = ops.model.ActiveStatus("fakestatus")
-
     e.harness.update_config({"role": role})
     e.harness.set_leader(is_leader)
     e.harness.begin_with_initial_hooks()

--- a/tests/unit/test_microk8s.py
+++ b/tests/unit/test_microk8s.py
@@ -318,21 +318,22 @@ def test_microk8s_configure_dns(apply_launch_configuration: mock.MagicMock):
 @mock.patch("util.run")
 def test_microk8s_get_kubernetes_version(run: mock.MagicMock):
     # parse output
+    run.return_value.stdout = b"microk8s 1.28.1 revision 4217\n"
+    version = microk8s.get_kubernetes_version()
+    run.assert_called_once_with(["microk8s", "version"], capture_output=True)
+    assert version == "1.28.1"
+
+    # parse output (drop v prefix)
     run.return_value.stdout = b"microk8s v1.28.1 revision 4217\n"
     version = microk8s.get_kubernetes_version()
-    run.assert_called_once_with(["microk8s", "version"], capture_output=True)
-    assert version == "v1.28.1"
+    assert version == "1.28.1"
 
     # invalid output
-    run.reset_mock()
     run.return_value.stdout = b"somethingwithoutspaces"
     version = microk8s.get_kubernetes_version()
-    run.assert_called_once_with(["microk8s", "version"], capture_output=True)
     assert version is None
 
     # exception
-    run.reset_mock()
     run.side_effect = subprocess.CalledProcessError(returncode=1, cmd="microk8s version")
     version = microk8s.get_kubernetes_version()
-    run.assert_called_once_with(["microk8s", "version"], capture_output=True)
     assert version is None

--- a/tests/unit/test_microk8s.py
+++ b/tests/unit/test_microk8s.py
@@ -1,6 +1,7 @@
 #
 # Copyright 2023 Canonical, Ltd.
 #
+import subprocess
 from pathlib import Path
 from unittest import mock
 
@@ -312,3 +313,26 @@ def test_microk8s_configure_dns(apply_launch_configuration: mock.MagicMock):
     apply_launch_configuration.assert_called_once_with(
         {"extraKubeletArgs": {"--cluster-dns": "fakeip", "--cluster-domain": "fakedomain"}}
     )
+
+
+@mock.patch("util.run")
+def test_microk8s_get_kubernetes_version(run: mock.MagicMock):
+    # parse output
+    run.return_value.stdout = b"microk8s v1.28.1 revision 4217\n"
+    version = microk8s.get_kubernetes_version()
+    run.assert_called_once_with(["microk8s", "version"], capture_output=True)
+    assert version == "v1.28.1"
+
+    # invalid output
+    run.reset_mock()
+    run.return_value.stdout = b"somethingwithoutspaces"
+    version = microk8s.get_kubernetes_version()
+    run.assert_called_once_with(["microk8s", "version"], capture_output=True)
+    assert version is None
+
+    # exception
+    run.reset_mock()
+    run.side_effect = subprocess.CalledProcessError(returncode=1, cmd="microk8s version")
+    version = microk8s.get_kubernetes_version()
+    run.assert_called_once_with(["microk8s", "version"], capture_output=True)
+    assert version is None


### PR DESCRIPTION
### Summary

Set the unit workload version to match the Kubernetes version of the unit (if available).

### Changes

- Add `microk8s.get_kubernetes_version()` and unit tests
- Change `charm.update_status` handler to set the workload version
- Small improvements to the unit test environment (initialize common settings once)

### Output

Adds the kubernetes version to the `juju status` output like this:

```bash
$ juju status microk8s
Model      Controller  Cloud/Region   Version  SLA          Timestamp
test-ceph  zs          zerostack/KHY  3.1.5    unsupported  10:22:23+03:00

App       Version          Status  Scale  Charm     Channel  Rev  Exposed  Message
microk8s  1.28.1           active      1  microk8s             5  no       node is ready

Unit           Workload  Agent  Machine  Public address  Ports      Message
microk8s/0*    active    idle   0        172.16.100.159  16443/tcp  node is ready

Machine  State    Address         Inst id                               Base          AZ    Message
0        started  172.16.100.159  6ae8f2ef-f140-47a9-8602-884d47c0e80f  ubuntu@20.04  nova  ACTIVE
```