### PR TITLE
configure containerd registries before waiting for microk8s on install

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -183,8 +183,13 @@ class MicroK8sCharm(CharmBase):
 
         self.unit.status = MaintenanceStatus("installing MicroK8s")
         microk8s.install()
+
+        self.unit.status = MaintenanceStatus("initial containerd configuration")
+        self.config_containerd_proxy(None)
+        self.config_containerd_registries(None)
         try:
-            microk8s.wait_ready()
+            if not isinstance(self.unit.status, BlockedStatus):
+                microk8s.wait_ready()
         except subprocess.CalledProcessError:
             LOG.exception("timed out waiting for node to come up")
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -26,7 +26,7 @@ def test_install(role, e: Environment):
 
     e.util.install_required_packages.assert_called_once_with()
     e.microk8s.install.assert_called_once_with()
-    e.microk8s.set_containerd_proxy_options.assert_called_once_with(
+    e.microk8s.set_containerd_proxy_options.assert_called_with(
         "fakehttpproxy", "fakehttpsproxy", "fakenoproxy"
     )
 


### PR DESCRIPTION
### Summary

Configure containerd registries and proxy before waiting for initial installation to complete.

### Description

When installing microk8s, we first wait for the node to become ready and then proceed with the `config-changed` hook to configure the cluster.

This poses a bootstrap problem: In environments where custom containerd configuration to fetch the required images, the initial `microk8s status --wait-ready` will take a very long time and eventually fail.

We deal with this by configuring containerd right after installation, and then proceeding to wait for the cluster to come up.