### PR TITLE
Fix handling of proxy configuration on integration tests

### DIFF
--- a/tests/integration/test_coredns.py
+++ b/tests/integration/test_coredns.py
@@ -18,13 +18,13 @@ DNS_TEST = "microk8s kubectl run -it --rm debug --image=busybox:1.28.4 --restart
 
 
 @pytest.mark.abort_on_fail
-async def test_core_dns(e: OpsTest):
+async def test_core_dns(e: OpsTest, charm_config: dict):
     # deploy microk8s
     if "microk8s" not in e.model.applications:
         await e.model.deploy(
             config.MK8S_CHARM,
             application_name="microk8s",
-            config={"hostpath_storage": "true"},
+            config={**charm_config, "hostpath_storage": "true"},
             channel=config.MK8S_CHARM_CHANNEL,
             constraints=config.MK8S_CONSTRAINTS,
         )

--- a/tests/integration/test_metallb_traefik.py
+++ b/tests/integration/test_metallb_traefik.py
@@ -36,7 +36,7 @@ async def test_metallb_traefik(e: OpsTest, charm_config: dict):
             await e.model.deploy(
                 config.MK8S_METALLB_CHARM,
                 application_name="metallb",
-                config={"iprange": "42.42.42.42-42.42.42.42"},
+                config={"iprange": "10.42.42.42-10.42.42.42"},
                 channel=config.MK8S_METALLB_CHANNEL,
             )
             await e.model.wait_for_idle(["metallb"])
@@ -57,11 +57,11 @@ async def test_metallb_traefik(e: OpsTest, charm_config: dict):
             await e.model.relate("traefik", "hello-kubecon")
 
         stdout = ""
-        while "42.42.42.42" not in stdout:
+        while "10.42.42.42" not in stdout:
             rc, stdout, stderr = await run_unit(u, f"microk8s kubectl get svc traefik -n {ns}")
             LOG.info("Check LoadBalancer service %s on %s", (rc, stdout, stderr), ns)
 
         # Make sure hello-kubecon is available from ingress
         while "Hello, Kubecon" not in stdout:
-            rc, stdout, stderr = await run_unit(u, f"curl http://42.42.42.42:80/{ns}-hello-kubecon")
+            rc, stdout, stderr = await run_unit(u, f"curl http://10.42.42.42:80/{ns}-hello-kubecon")
             LOG.info("Waiting for hello kubecon message %s", (rc, stderr))

--- a/tests/integration/test_metallb_traefik.py
+++ b/tests/integration/test_metallb_traefik.py
@@ -15,13 +15,13 @@ LOG = logging.getLogger(__name__)
 
 
 @pytest.mark.abort_on_fail
-async def test_metallb_traefik(e: OpsTest):
+async def test_metallb_traefik(e: OpsTest, charm_config: dict):
     # deploy microk8s
     if "microk8s" not in e.model.applications:
         await e.model.deploy(
             config.MK8S_CHARM,
             application_name="microk8s",
-            config={"hostpath_storage": "true"},
+            config={**charm_config, "hostpath_storage": "true"},
             channel=config.MK8S_CHARM_CHANNEL,
             constraints=config.MK8S_CONSTRAINTS,
         )

--- a/tests/integration/test_microk8s.py
+++ b/tests/integration/test_microk8s.py
@@ -13,10 +13,11 @@ from pytest_operator.plugin import OpsTest
 @pytest.mark.abort_on_fail
 @pytest.mark.parametrize("cp_units, worker_units", config.MK8S_CLUSTER_SIZES)
 @pytest.mark.parametrize("series", config.MK8S_SERIES)
-async def test_microk8s_cluster(e: OpsTest, series: str, cp_units: int, worker_units: int):
+async def test_microk8s_cluster(
+    e: OpsTest, charm_config: dict, series: str, cp_units: int, worker_units: int
+):
     """Deploy a cluster, configure RBAC, wait for units to come up"""
 
-    charm_config = {}
     application_name = f"microk8s-{series or 'default'}-{cp_units}c{worker_units}w"
 
     apps = []

--- a/tests/integration/test_observability.py
+++ b/tests/integration/test_observability.py
@@ -9,12 +9,13 @@ from pytest_operator.plugin import OpsTest
 
 
 @pytest.mark.abort_on_fail
-async def test_observability_metrics(e: OpsTest):
+async def test_observability_metrics(e: OpsTest, charm_config: dict):
     await e.model.deploy(
         config.MK8S_CHARM,
         application_name="microk8s",
         channel=config.MK8S_CHARM_CHANNEL,
         constraints=config.MK8S_CONSTRAINTS,
+        config=charm_config,
     )
     await e.model.wait_for_idle(["microk8s"])
 


### PR DESCRIPTION
### Summary

Ensure that containerd proxy configuration is passed properly when running the integration tests

### Changes

- Use a local address `10.42.42.42` for the LoadBalancer IP, because `42.42.42.42` might rightfully not be included in the `no_proxy` config
- Add a `charm_config` fixture with common charm configuration, at the moment the containerd http proxy config
- Use the `charm_config` fixture in existing tests