### PR TITLE
reduce over-verbose debug logs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,7 +74,6 @@ jobs:
           mkdir artifacts
           juju debug-log -m testing --replay > artifacts/juju.log
           juju status -m testing --format yaml > artifacts/juju.yaml
-          cp pytest.log artifacts/pytest.log
       - name: Upload artifacts
         if: always()
         uses: actions/upload-artifact@v3.1.2
@@ -124,7 +123,6 @@ jobs:
           mkdir artifacts
           juju debug-log -m testing --replay > artifacts/juju.log
           juju status -m testing --format yaml > artifacts/juju.yaml
-          cp pytest.log artifacts/pytest.log
       - name: Upload artifacts
         if: always()
         uses: actions/upload-artifact@v3.1.2
@@ -174,7 +172,6 @@ jobs:
           mkdir artifacts
           juju debug-log -m testing --replay > artifacts/juju.log
           juju status -m testing --format yaml > artifacts/juju.yaml
-          cp pytest.log artifacts/pytest.log
       - name: Upload artifacts
         if: always()
         uses: actions/upload-artifact@v3.1.2
@@ -224,7 +221,6 @@ jobs:
           mkdir artifacts
           juju debug-log -m testing --replay > artifacts/juju.log
           juju status -m testing --format yaml > artifacts/juju.yaml
-          cp pytest.log artifacts/pytest.log
       - name: Upload artifacts
         if: always()
         uses: actions/upload-artifact@v3.1.2

--- a/tox.ini
+++ b/tox.ini
@@ -64,8 +64,6 @@ commands =
     pytest -v \
            -s \
            --tb native \
-           --log-file-level DEBUG \
-           --log-file pytest.log \
            --log-cli-level INFO \
            --disable-warnings \
            {posargs} \
@@ -83,8 +81,6 @@ commands =
     pytest -v \
            -s \
            --tb native \
-           --log-file-level DEBUG \
-           --log-file pytest.log \
            --log-cli-level INFO \
            --disable-warnings \
            {posargs} \


### PR DESCRIPTION
### Summary

Remove the debug logs from the output, since they only produce clatter in failed runs.