### PR TITLE
Add get-kubeconfig action

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -1,0 +1,2 @@
+get-kubeconfig:
+  description: Retrieve a kubeconfig for the microk8s node

--- a/src/microk8s.py
+++ b/src/microk8s.py
@@ -229,8 +229,13 @@ def configure_rbac(enable: bool):
 
 def write_local_kubeconfig():
     """write kubeconfig file for the cluster"""
-    p = util.ensure_call(["microk8s", "config"], capture_output=True)
-    util.ensure_file(Path("/root/.kube/config"), p.stdout.decode(), 0o600, 0, 0)
+    p = util.ensure_call(["microk8s", "config", "-l"], capture_output=True)
+
+    kubeconfig = p.stdout.decode()
+    util.ensure_file(Path("/root/.kube/config"), kubeconfig, 0o600, 0, 0)
+
+    kubeconfig = kubeconfig.replace("127.0.0.1", ops_helpers.get_unit_public_address())
+    util.ensure_file(Path("/root/config"), kubeconfig, 0o600, 0, 0)
 
 
 def configure_dns(ip: str, domain: str):

--- a/src/microk8s.py
+++ b/src/microk8s.py
@@ -230,12 +230,13 @@ def configure_rbac(enable: bool):
 def write_local_kubeconfig():
     """write kubeconfig file for the cluster"""
     p = util.ensure_call(["microk8s", "config", "-l"], capture_output=True)
+    util.ensure_file(Path("/root/.kube/config"), p.stdout.decode(), 0o600, 0, 0)
 
-    kubeconfig = p.stdout.decode()
-    util.ensure_file(Path("/root/.kube/config"), kubeconfig, 0o600, 0, 0)
 
-    kubeconfig = kubeconfig.replace("127.0.0.1", ops_helpers.get_unit_public_address())
-    util.ensure_file(Path("/root/config"), kubeconfig, 0o600, 0, 0)
+def get_public_kubeconfig() -> str:
+    """return a kubeconfig that uses the public address of the unit"""
+    p = util.ensure_call(["microk8s", "config", "-l"], capture_output=True)
+    return p.stdout.decode().replace("127.0.0.1", ops_helpers.get_unit_public_address())
 
 
 def configure_dns(ip: str, domain: str):

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -88,12 +88,12 @@ async def microk8s_kubernetes_cloud_and_model(ops_test: OpsTest, microk8s_applic
 
     await ops_test.model.wait_for_idle([microk8s_application])
 
-    rc, kubeconfig, _ = await run_unit(app.units[0], "cat /root/config")
-    if rc != 0:
-        raise Exception(f"failed to retrieve microk8s config {rc, kubeconfig}")
+    # get-kubeconfig from the application
+    unit: Unit = app.units[0]
+    action: Action = await unit.run_action("get-kubeconfig")
+    result: dict = await ops_test.model.get_action_output(action.entity_id)
+    kubeconfig = result["kubeconfig"]
 
-    # In some clouds the IP in kubeconfig returned by microk8s config is not the public IP
-    # where the API server is found.
     cloud_name = f"k8s-{ops_test._generate_model_name()}"
     model_name = f"k8s-{ops_test._generate_model_name()}"
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -88,13 +88,12 @@ async def microk8s_kubernetes_cloud_and_model(ops_test: OpsTest, microk8s_applic
 
     await ops_test.model.wait_for_idle([microk8s_application])
 
-    rc, kubeconfig, _ = await run_unit(app.units[0], "microk8s config -l")
+    rc, kubeconfig, _ = await run_unit(app.units[0], "cat /root/config")
     if rc != 0:
         raise Exception(f"failed to retrieve microk8s config {rc, kubeconfig}")
 
     # In some clouds the IP in kubeconfig returned by microk8s config is not the public IP
     # where the API server is found.
-    kubeconfig = kubeconfig.replace("127.0.0.1", app.units[0].public_address)
     cloud_name = f"k8s-{ops_test._generate_model_name()}"
     model_name = f"k8s-{ops_test._generate_model_name()}"
 

--- a/tests/unit/test_microk8s.py
+++ b/tests/unit/test_microk8s.py
@@ -297,24 +297,29 @@ def test_microk8s_configure_rbac(
 
 @mock.patch("util.ensure_call", autospec=True)
 @mock.patch("util.ensure_file", autospec=True)
-@mock.patch("ops_helpers.get_unit_public_address", autospec=True)
-def test_microk8s_write_local_kubeconfig(
-    get_unit_public_address: mock.MagicMock,
-    ensure_file: mock.MagicMock,
-    ensure_call: mock.MagicMock,
-):
-    get_unit_public_address.return_value = "10.0.0.10"
+def test_microk8s_write_local_kubeconfig(ensure_file: mock.MagicMock, ensure_call: mock.MagicMock):
     ensure_call.return_value.stdout = b"some kubeconfig that contains 127.0.0.1"
 
     microk8s.write_local_kubeconfig()
 
     ensure_call.assert_called_once_with(["microk8s", "config", "-l"], capture_output=True)
-    assert ensure_file.mock_calls == [
-        mock.call(
-            Path("/root/.kube/config"), "some kubeconfig that contains 127.0.0.1", 0o600, 0, 0
-        ),
-        mock.call(Path("/root/config"), "some kubeconfig that contains 10.0.0.10", 0o600, 0, 0),
-    ]
+    ensure_file.assert_called_once_with(
+        Path("/root/.kube/config"), "some kubeconfig that contains 127.0.0.1", 0o600, 0, 0
+    )
+
+
+@mock.patch("util.ensure_call", autospec=True)
+@mock.patch("ops_helpers.get_unit_public_address", autospec=True)
+def test_microk8s_get_public_kubeconfig(
+    get_unit_public_address: mock.MagicMock, ensure_call: mock.MagicMock
+):
+    get_unit_public_address.return_value = "10.0.0.10"
+    ensure_call.return_value.stdout = b"some kubeconfig that contains 127.0.0.1"
+
+    kubeconfig = microk8s.get_public_kubeconfig()
+
+    ensure_call.assert_called_once_with(["microk8s", "config", "-l"], capture_output=True)
+    assert kubeconfig == "some kubeconfig that contains 10.0.0.10"
 
 
 @mock.patch("microk8s.apply_launch_configuration")


### PR DESCRIPTION
### Summary

Create a `get-kubeconfig` action. It can be used to retrieve a kubeconfig file to use kubectl against the public address of a unit.

Example:

```bash
juju run microk8s/0 get-kubeconfig
```

Example, create `~/.kube/config`:

```bash
juju run microk8s/1 get-kubeconfig  | sed '/kubeconfig:/d' | sed 's/^  //' > ~/.kube/config
```

### Changes

- Improve the UX of retrieving a cluster kubeconfig
- Adjust integration tests to use this kubeconfig instead of building one manually