### PR TITLE
(docfix) Rename config variable "insecure_skip_verify" to "skip_verify".

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -106,9 +106,9 @@ options:
         For ssl/tls communication these should be a base64 encoded file
         e.g.:  "ca_file": "'"$(base64 -w 0 < my.custom.registry.pem)"'"
 
-      insecure_skip_verify: OPTIONAL bool - default false
+      skip_verify: OPTIONAL bool - default false
         For situatations where the registry has self-signed or expired certs and a quick work-around is necessary.
-        e.g.: "insecure_skip_verify": true
+        e.g.: "skip_verify": true
 
       example config)
       juju config containerd custom_registries='[{


### PR DESCRIPTION
### Summary
Rename "insecure_skip_verify" to "skip_verify" per [charm code](https://github.com/canonical/charm-microk8s/blob/master/src/containerd.py#L35).

Closes #127.

### Changes

- Adjust variable name on `config.yaml`.