### PR TITLE
bump pytest-operator to include fixes

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,4 @@
 coverage[toml]==7.2.5
 pytest==7.3.1
 
-pytest-operator==0.29.0
+pytest-operator==0.31.1


### PR DESCRIPTION
### Summary

Bump pytest-operator to include latest bugfixes.

This is an attempt to fix the integration tests, which are currently failing