### PR TITLE
Add proxy configuration options

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -8,22 +8,26 @@ options:
     description: A space-separated list of addons that should be enabled.
     type: string
     default: dns ingress
-  containerd_env:
-    description: >
-      Contents of the containerd-env file.
+  containerd_http_proxy:
+    description: |
+      Set an HTTP proxy to be used by containerd to pull images from image registries. This is
+      useful when deploying the charm on a constrained environment.
+      Example: "http://squid.internal:3128"
+    default: ""
     type: string
-    default: |
-      # This file is managed by Juju. Manual changes may be lost at any time.
-
-      # Configure limits for locked memory and maximum number of open files
-      ulimit -n 65536 || true
-      ulimit -l 16384 || true
-
-      # Uncomment to configure a proxy for containerd
-      # HTTP_PROXY=http://squid.internal:3128
-      # HTTPS_PROXY=http://squid.internal:3128
-      # NO_PROXY=10.0.0.0/8,127.0.0.0/16,192.168.0.0/16
-
+  containerd_https_proxy:
+    description: |
+      Set an HTTPS proxy to be used by containerd to pull images from image registries. This is
+      useful when deploying the charm on a constrained environment.
+      Example: "http://squid.internal:3128"
+    default: ""
+    type: string
+  containerd_no_proxy:
+    description: |
+      When configuring an HTTP/HTTPS proxy for containerd, specify the list of IP ranges to exclude.
+      Example: "127.0.0.1,10.0.0.0/8,192.168.0.0/16,172.16.0.0/12"
+    default: ""
+    type: string
   custom_registries:
     type: string
     default: "[]"

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,7 +1,10 @@
 import json
 import logging
 import os
+import shlex
 import subprocess
+import time
+from pathlib import Path
 from time import sleep
 
 
@@ -128,3 +131,70 @@ def check_kubernetes_version_is_older(current: str, new: str):
         return current_version > new_version
     except (TypeError, ValueError):
         return False
+
+
+def run(*args, **kwargs) -> subprocess.CompletedProcess:
+    """log and run command"""
+    kwargs.setdefault("check", True)
+
+    logger.debug("Execute: %s (args=%s, kwargs=%s)", shlex.join(args[0]), args, kwargs)
+    return subprocess.run(*args, **kwargs)
+
+
+def ensure_file(file: Path, data: str, permissions: int = None, uid: int = None, gid: int = None) -> bool:
+    """ensure file with specific contents, owner:group and permissions exists on disk.
+    returns `True` if file contents have changed"""
+
+    # ensure directory exists
+    file.parent.mkdir(parents=True, exist_ok=True)
+
+    changed = False
+    if not file.exists() or file.read_text() != data:
+        file.write_text(data)
+        changed = True
+
+    if permissions is not None:
+        os.chmod(file, permissions)
+
+    if uid is not None and gid is not None:
+        os.chown(file, uid, gid)
+
+    return changed
+
+
+def ensure_block(data: str, block: str, block_marker: str) -> str:
+    """return a copy of data and ensure that it contains `block`, surrounded by the specified
+    `block_marker`. `block_marker` can contain `{mark}`, which is replaced with begin and end
+    """
+
+    if block_marker:
+        marker_begin = "\n" + block_marker.replace("{mark}", "begin") + "\n"
+        marker_end = "\n" + block_marker.replace("{mark}", "end") + "\n"
+    else:
+        marker_begin, marker_end = "\n", "\n"
+
+    begin_index = data.rfind(marker_begin)
+    end_index = data.find(marker_end, begin_index + 1)
+
+    if begin_index == -1 or end_index == -1:
+        return f"{data}{marker_begin}{block}{marker_end}"
+
+    return f"{data[:begin_index]}{marker_begin}{block}{data[end_index:]}"
+
+
+def _ensure_func(f: callable, args: list, kwargs: dict, retry_on, max_retries: int = 10, backoff: int = 2):
+    """run a function until it does not raise one of the exceptions from retry_on"""
+    for idx in range(max_retries - 1):
+        try:
+            return f(*args, **kwargs)
+        except retry_on:
+            logger.exception("action not successful (try %d of %d)", idx + 1, max_retries)
+            time.sleep(backoff)
+
+    # last time run unprotected and raise any exception
+    return f(*args, **kwargs)
+
+
+def ensure_call(*args, **kwargs) -> subprocess.CompletedProcess:
+    """repeatedly run a command until it succeeds. any args are passed to subprocess.check_call"""
+    return _ensure_func(run, args, kwargs, subprocess.CalledProcessError)


### PR DESCRIPTION
Add explicit proxy configuration options to
the charm and remove containerd_env option.

This functionality is supported on master but
not on legacy. So tried to backport required
code from [1]

[1] https://github.com/canonical/charm-microk8s/commit/ce10bc9fde177f4cb7d79535d7418d5656fa763c