### PR TITLE
Bump actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -47,7 +47,7 @@ jobs:
           done
       - name: Upload artifacts
         if: always()
-        uses: actions/upload-artifact@v3.1.2
+        uses: actions/upload-artifact@v4
         with:
           name: Logs
           path: artifacts/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
           charmcraft pack -v --destructive-mode
           mv microk8s*.charm microk8s.charm
       - name: Upload charm
-        uses: actions/upload-artifact@v3.1.2
+        uses: actions/upload-artifact@v4
         with:
           name: microk8s.charm
           path: ./microk8s.charm
@@ -76,7 +76,7 @@ jobs:
           juju status -m testing --format yaml > artifacts/juju.yaml
       - name: Upload artifacts
         if: always()
-        uses: actions/upload-artifact@v3.1.2
+        uses: actions/upload-artifact@v4
         with:
           name: Cluster - ${{ matrix.control_plane}}cp${{ matrix.workers}}w - ${{ matrix.series }} - juju ${{ matrix.juju }}
           path: artifacts/
@@ -125,7 +125,7 @@ jobs:
           juju status -m testing --format yaml > artifacts/juju.yaml
       - name: Upload artifacts
         if: always()
-        uses: actions/upload-artifact@v3.1.2
+        uses: actions/upload-artifact@v4
         with:
           name: Traefik - juju ${{ matrix.juju }}
           path: artifacts/
@@ -174,7 +174,7 @@ jobs:
           juju status -m testing --format yaml > artifacts/juju.yaml
       - name: Upload artifacts
         if: always()
-        uses: actions/upload-artifact@v3.1.2
+        uses: actions/upload-artifact@v4
         with:
           name: Observability - juju ${{ matrix.juju }}
           path: artifacts/
@@ -223,7 +223,7 @@ jobs:
           juju status -m testing --format yaml > artifacts/juju.yaml
       - name: Upload artifacts
         if: always()
-        uses: actions/upload-artifact@v3.1.2
+        uses: actions/upload-artifact@v4
         with:
           name: CoreDNS - juju ${{ matrix.juju }}
           path: artifacts/
@@ -272,7 +272,7 @@ jobs:
           juju status -m testing --format yaml > artifacts/juju.yaml
       - name: Upload artifacts
         if: always()
-        uses: actions/upload-artifact@v3.1.2
+        uses: actions/upload-artifact@v4
         with:
           name: Ceph - juju ${{ matrix.juju }}
           path: artifacts/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Add user to lxd group
         run: sudo usermod -a -G lxd $USER
       - name: Fetch charm
-        uses: actions/download-artifact@v3.0.2
+        uses: actions/download-artifact@v4
         with:
           name: microk8s.charm
           path: build
@@ -103,7 +103,7 @@ jobs:
       - name: Add user to lxd group
         run: sudo usermod -a -G lxd $USER
       - name: Fetch charm
-        uses: actions/download-artifact@v3.0.2
+        uses: actions/download-artifact@v4
         with:
           name: microk8s.charm
           path: build
@@ -152,7 +152,7 @@ jobs:
       - name: Add user to lxd group
         run: sudo usermod -a -G lxd $USER
       - name: Fetch charm
-        uses: actions/download-artifact@v3.0.2
+        uses: actions/download-artifact@v4
         with:
           name: microk8s.charm
           path: build
@@ -201,7 +201,7 @@ jobs:
       - name: Add user to lxd group
         run: sudo usermod -a -G lxd $USER
       - name: Fetch charm
-        uses: actions/download-artifact@v3.0.2
+        uses: actions/download-artifact@v4
         with:
           name: microk8s.charm
           path: build
@@ -250,7 +250,7 @@ jobs:
       - name: Add user to lxd group
         run: sudo usermod -a -G lxd $USER
       - name: Fetch charm
-        uses: actions/download-artifact@v3.0.2
+        uses: actions/download-artifact@v4
         with:
           name: microk8s.charm
           path: build


### PR DESCRIPTION
actions/upload-artifact@v3 is deprecated, we'll need to switch to v4.

https://github.com/actions/upload-artifact?tab=readme-ov-file#breaking-changes